### PR TITLE
Us377646 num total participantes

### DIFF
--- a/EjerciciosLog/MoodleAnalysisLibrary.py
+++ b/EjerciciosLog/MoodleAnalysisLibrary.py
@@ -5,8 +5,10 @@ import matplotlib.pyplot as plt
 class MoodleAnalysisLibrary():
     dataframe = pd.DataFrame
     def __init__(self, name, path, userstodelete):
-        #self.dataframe=MoodleAnalysisLibrary.createDataFrame(self,name, path)
-        self.dataframe=MoodleAnalysisLibrary.createDataFrameFileName(self,name)
+        if path!="":
+            self.dataframe=MoodleAnalysisLibrary.createDataFrame(self,name, path)
+        else:
+            self.dataframe=MoodleAnalysisLibrary.createDataFrameFileName(self,name)
         self.dataframe=MoodleAnalysisLibrary.addIDColumn(self, self.dataframe)
         self.dataframe=MoodleAnalysisLibrary.deleteByID(self,self.dataframe,userstodelete)
         self.dataframe = self.dataframe[~self.dataframe['Nombre completo del usuario'].isin(['-'])] #OJO,PODRÍA PASARSE SU ID COMO ARGUMENTO, POR EL MOMENTO DELETEBYID NO CONTEMPLA NEGATIVOS
@@ -283,6 +285,24 @@ class MoodleAnalysisLibrary():
 
         """
         return (dataframe['IDUsuario'].nunique() - MoodleAnalysisLibrary.numTeachers(self,dataframe))
+
+    def num_participants_nonparticipants(self, dataframe, dataframeusuarios):
+        data={'Participantes':[0],'No participantes':[0]}
+        df=pd.DataFrame(data)
+        df['Participantes']=dataframe['IDUsuario'].nunique()
+        for fila in dataframeusuarios.iterrows():
+            if fila[1]['Nombre completo del usuario'] not in dataframe['Nombre completo del usuario'].values:
+                # df['Nombre no participante']=fila[1]['Nombre completo del usuario']
+                df['No participantes']=df['No participantes']+1
+        return df
+
+    def list_nonparticipant(self, dataframe, dataframeusuarios):
+        result=list()
+        for fila in dataframeusuarios['Nombre completo del usuario']:
+            if fila not in dataframe['Nombre completo del usuario'].values:
+                result.append(fila)
+        df=pd.DataFrame(result,columns=['Nombre completo del usuario'])
+        return df
 
     def numEventsPerParticipant(self, dataframe):
         """

--- a/EjerciciosLog/MoodleAnalysisLibrary.py
+++ b/EjerciciosLog/MoodleAnalysisLibrary.py
@@ -287,20 +287,61 @@ class MoodleAnalysisLibrary():
         return (dataframe['IDUsuario'].nunique() - MoodleAnalysisLibrary.numTeachers(self,dataframe))
 
     def num_participants_nonparticipants(self, dataframe, dataframeusuarios):
+        """
+        Summary line.
+
+        Calcula el número de usuarios participantes y el de no participantes.
+
+        Parameters
+        ----------
+        arg1 : dataframe
+            Log en el que contar los participantes.
+
+        arg2 : dataframe
+            Dataframe en el que contar todos los usuarios (participantes y no participantes).
+
+        Returns
+        -------
+        Dataframe
+            Dataframe con una columna para el número de participantes y otra para el número que no
+            participantes.
+
+        """
         data={'Participantes':[0],'No participantes':[0]}
         df=pd.DataFrame(data)
         df['Participantes']=dataframe['IDUsuario'].nunique()
         for fila in dataframeusuarios.iterrows():
             if fila[1]['Nombre completo del usuario'] not in dataframe['Nombre completo del usuario'].values:
-                # df['Nombre no participante']=fila[1]['Nombre completo del usuario']
                 df['No participantes']=df['No participantes']+1
         return df
 
     def list_nonparticipant(self, dataframe, dataframeusuarios):
+        """
+        Summary line.
+
+        Recoge a los usuarios no participantes
+
+        Parameters
+        ----------
+        arg1 : dataframe
+            Log en el que contar los participantes.
+
+        arg2 : dataframe
+            Dataframe con todos los usuarios (participantes y no participantes).
+
+        Returns
+        -------
+        Dataframe
+            Dataframe con una columna con la lista de todos los usuarios no participantes.
+
+        """
         result=list()
         for fila in dataframeusuarios['Nombre completo del usuario']:
             if fila not in dataframe['Nombre completo del usuario'].values:
                 result.append(fila)
+        if(result==[]):
+            df = pd.DataFrame(result, columns=['TODOS HAN PARTICIPADO'])
+            return df
         df=pd.DataFrame(result,columns=['Nombre completo del usuario'])
         return df
 

--- a/EjerciciosLog/PREZv0.0.1.py
+++ b/EjerciciosLog/PREZv0.0.1.py
@@ -1,0 +1,75 @@
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+import MoodleAnalysisLibrary
+import pandas as pd
+
+prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_G668_1819_20191223-1648.csv",
+                                                      "C:/Users/sal8b/OneDrive/Escritorio/Beca", ['0', '-1']))
+usuarios = (pd.DataFrame({'Nombre completo del usuario': ['Sanchez Barreiro, Pablo', 'speos', 'jbdbje']}))
+
+external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+
+app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+
+colors = {
+    'background': '#FFFFFF',
+    'text': '#000000'
+}
+
+app.layout = html.Div(style={'backgroundColor': colors['background']}, children=[
+    html.H1(
+        children='Log Curso 2018-2019',
+        style={
+            'textAlign': 'center',
+            'color': colors['text'],
+            'font-family': 'sa'
+        }
+    ),
+    html.H2(
+        children='Métodos de Desarrollo',
+        style={
+            'textAlign': 'center',
+            'color': colors['text'],
+            'font-family': 'sa'
+        }
+    ),
+    html.Div(children=[
+        html.Div(
+            dcc.Graph(
+                figure={
+                    'data': [
+                        {'labels': ['Participantes', 'No Participantes'],
+                         'values': [
+                             prueba.num_participants_nonparticipants(prueba.dataframe, usuarios)['Participantes'][0],
+                             prueba.num_participants_nonparticipants(prueba.dataframe, usuarios)['No participantes'][
+                                 0]], 'type': 'pie',
+                         'automargin': True,
+                         'textinfo': 'none'},
+                    ],
+                    'layout': {
+                        'title': 'Eventos por recurso',
+                    }
+                }
+            ), style={'display': 'inline-block'}
+        ),
+
+        html.Div(children=[
+            html.H3(
+                children='Usuarios no participantes',
+                style={
+                    'textAlign': 'center',
+                    'color': colors['text'],
+                    'font-family': 'sa'
+                }
+            ),
+            html.Iframe(srcDoc=prueba.list_nonparticipant(prueba.dataframe, usuarios).to_html(index=False, columns=[
+                "Nombre completo del usuario"]), ),
+        ],
+        style={'display': 'inline-block'}, )
+    ], style={'text-align': 'center'})
+
+])
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/EjerciciosLog/PREZv0.0.1.py
+++ b/EjerciciosLog/PREZv0.0.1.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_G668_1819_20191223-1648.csv",
                                                       "C:/Users/sal8b/OneDrive/Escritorio/Beca", ['0', '-1']))
-usuarios = (pd.DataFrame({'Nombre completo del usuario': ['Sanchez Barreiro, Pablo', 'speos', 'jbdbje']}))
+usuarios = (pd.DataFrame({'Nombre completo del usuario': ['Sanchez Barreiro, Pablo',"CUADRIELLO GALDÓS, ÁNGELA","CUEVAS RODRIGUEZ, SARA","DE SÁDABA IGAREDA, CELIA","SAL SARRIA, SAÚL","DE SANTIAGO ABASCAL, GABRIELA","CIDÓN HOFFMAN, JAIME"]}))
 
 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 
@@ -63,10 +63,9 @@ app.layout = html.Div(style={'backgroundColor': colors['background']}, children=
                     'font-family': 'sa'
                 }
             ),
-            html.Iframe(srcDoc=prueba.list_nonparticipant(prueba.dataframe, usuarios).to_html(index=False, columns=[
-                "Nombre completo del usuario"]), ),
+            html.Iframe(srcDoc=prueba.list_nonparticipant(prueba.dataframe, usuarios).to_html(index=False)),
         ],
-        style={'display': 'inline-block'}, )
+        style={'display': 'inline-block', 'white-space': 'nowrap'}, )
     ], style={'text-align': 'center'})
 
 ])

--- a/EjerciciosLog/test_moodleAnalysisLibrary.py
+++ b/EjerciciosLog/test_moodleAnalysisLibrary.py
@@ -6,6 +6,9 @@ import numpy as np
 
 prueba1Rows = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("TestingLog1Row.csv","", []))
 prueba99Rows = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("TestingLog99Rows.csv","", []))
+usuarios = (pd.DataFrame({'Nombre completo del usuario': ['Sanchez Barreiro, Pablo', 'Pedro', 'JAVI','RODRIGUEZ PÉREZ, DANIEL']}))
+usuariosvacia = (pd.DataFrame({'Nombre completo del usuario': []}))
+
 
 class TestMoodleAnalysisLibrary(unittest.TestCase):
 
@@ -67,7 +70,6 @@ class TestMoodleAnalysisLibrary(unittest.TestCase):
 
     def test_numEvents(self):
         self.assertTrue(prueba1Rows.numEvents(prueba1Rows.dataframe)==1)
-        print(prueba99Rows.numEvents(prueba99Rows.dataframe))
         self.assertTrue(prueba99Rows.numEvents(prueba99Rows.dataframe)==53)
 
     def test_numTeachers(self):
@@ -82,6 +84,25 @@ class TestMoodleAnalysisLibrary(unittest.TestCase):
 
     def test_numEventsPerParticipant(self):
         self.assertTrue((((prueba1Rows.numEventsPerParticipant(prueba1Rows.dataframe))['Número de eventos'][0])==1))
+
+    def test_num_participants_nonparticipants(self):
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,usuarios))['Participantes'][0]==13)
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,usuarios))['No participantes'][0]==4)
+
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,usuariosvacia))['Participantes'][0]==13)
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,usuariosvacia))['No participantes'][0]==0)
+
+
+
+    def test_list_nonparticipant(self):
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,usuarios))['Nombre completo del usuario'][0]=='Sanchez Barreiro, Pablo')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,usuarios))['Nombre completo del usuario'][1]=='Pedro')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,usuarios))['Nombre completo del usuario'][2]=='JAVI')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,usuarios))['Nombre completo del usuario'][3]=='RODRIGUEZ PÉREZ, DANIEL')
+
+
+        self.assertTrue('TODOS HAN PARTICIPADO' in (prueba99Rows.list_nonparticipant(prueba99Rows.dataframe, usuariosvacia).columns))
+
 
     # def test_eventsPerMonth(self):
     #     self.fail()


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de la historia de usuario de esta rama era proporcionar al usuario una idea de la participación en su curso de Moodle, si se había participado o no, en primera instancia. De esta forma, quería que se mostrase un gráfico circular contraponiendo el número de participantes con el de no participantes (la suma de ambos compondría el número total de usuarios). Por otro lado, interesaba identificar a los que fuesen no participantes.

Para ello se desarrollaron dos funciones en _MoodleAnalysisLibrary_ _num_participants_nonparticipants_ y _list_nonparticipant_. La primera de ellas, con el cometido de contar los participantes y los no participantes. Y la segunda con el de identificar a los no participantes. Para la interfaz gráfica se utilizó Dash, realizando representando los resultados de estas funciones en una pie chart y en un Iframe al lado derecho de esta.

Para el desarrollo de esta historia de usuario, como ya se comentó era necesaria la introducción de los usuarios. Teniendo acceso únicamente a los logs solo se tiene acceso a los participantes, no a todos los usuarios (participantes y no participantes). Para solventar temporalmente este contratiempo, se le pasa un DataFrame con los nombre de todos los usuarios. Esto podrá tratarse en un futuro de otro forma, con otros csv que transformaremos en dataframes con los nombres de los usuarios.

Tras esto, se realizaron las pruebas de aceptación con datos reales y las unitarias y de integración, que pueden encontrarse en _test_moodleAnalysisLibrary_ con datos ficticios. Estas pruebas fueron ejecutadas satisfactoriamente.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.
