### PR TITLE
Us380987 num total participantes por recurso

### DIFF
--- a/EjerciciosLog/MoodleAnalysisLibrary.py
+++ b/EjerciciosLog/MoodleAnalysisLibrary.py
@@ -478,6 +478,30 @@ class MoodleAnalysisLibrary():
         resultdf = resultdf.sort_values(ascending=False,by=['Número de eventos'])
         return resultdf
 
+    def participants_per_resource(self, dataframe):
+        """
+        Summary line. SPRINT02
+
+        Calcula el número de participantes por recurso del dataframe.
+
+        Parameters
+        ----------
+        dataframe : dataframe
+            Log en el que calcular el número de participantes por recurso.
+
+        Returns
+        -------
+        series??int
+            Lista con los recursos y su número de eventos.
+
+        """
+        result = dataframe.groupby(CONTEXTO)[ID_USUARIO].nunique()
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=['Número de participantes']))
+        resultdf['Recurso'] = resultdf.index
+        resultdf.reset_index(drop=True, inplace=True)
+        resultdf = resultdf.sort_values(ascending=False, by=['Número de participantes'])
+        return resultdf
+
     def events_per_hour(self, dataframe):
         """
         Summary line.

--- a/EjerciciosLog/PREZv0.0.3.py
+++ b/EjerciciosLog/PREZv0.0.3.py
@@ -4,7 +4,6 @@ import dash_core_components as dcc
 import dash_html_components as html
 import MoodleAnalysisLibrary
 
-
 prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_G668_1819_20191223-1648.csv",
                                                       "C:/Users/sal8b/OneDrive/Escritorio/Beca", "Usuarios.csv",
                                                       ['0', '323', '231']))
@@ -31,15 +30,81 @@ app.layout = html.Div(children=[
             'color': colors['text'],
         }
     ),
+    html.Div(
+        children=[
+            html.Div(
+                className='four columns',
+                children=[
+                    html.H3(
+                        children='Usuarios no participantes',
+                        style={
+                            'textAlign': 'center',
+                            'color': colors['text'],
+                        }
+                    ),
+                    dash_table.DataTable(
+                        id='table',
+                        columns=[{"name": i, "id": i} for i in
+                                 prueba.list_nonparticipant(prueba.dataframe, prueba.dataframe_Usuarios).columns],
+                        data=prueba.list_nonparticipant(prueba.dataframe, prueba.dataframe_Usuarios).to_dict(
+                            'records'),
+                        style_header={'backgroundColor': colors['background']},
+                        style_cell={'textAlign': 'left',
+                                    'backgroundColor': 'rgb(50, 50, 50)',
+                                    'color': colors['text'],
+                                    },
+                        style_table={
+                            'maxHeight': '200px',
+                            'maxWidth': '400px',
+                            'overflowY': 'scroll'
+                        },
+                    ),
+                ],
+                style={'marginLeft': '150px'}
+            ),
+            html.Div(
+                children=[
+                    dcc.Graph(
+                        id='pie-chart-participants-users',
+                        figure={
+                            'data': [
+                                {'labels': ['Participantes', 'No Participantes'],
+                                 'values': [
+                                     prueba.num_participants_nonparticipants(prueba.dataframe,
+                                                                             prueba.dataframe_Usuarios)[
+                                         'Participantes'][0],
+                                     prueba.num_participants_nonparticipants(prueba.dataframe,
+                                                                             prueba.dataframe_Usuarios)[
+                                         'No participantes'][0]], 'type': 'pie',
+                                 'automargin': True,
+                                 'textinfo': 'none'
+                                 },
+                            ],
+                            'layout': {
+                                'title': 'Eventos por recurso',
+                                "titlefont": {
+                                    "size": 23
+                                },
+                                'plot_bgcolor': colors['background'],
+                                'paper_bgcolor': colors['background'],
+                                'font': {
+                                    'color': colors['text']
+                                }
+                            }
+                        }
+                    )], style={'display': 'inline-block'},
+            ),
+
+        ], ),
     dcc.Graph(
-        id='EventosPorRecurso',
+        id='ParticipantesPorRecurso',
         figure={
             'data': [
-                {'x': prueba.events_per_resource(prueba.dataframe)['Número de eventos'],
-                 'y': prueba.events_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation':'h'},
+                {'x': prueba.participants_per_resource(prueba.dataframe)['Número de participantes'],
+                 'y': prueba.participants_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation': 'h'},
             ],
             'layout': {
-                'title': 'Recursos por número de eventos',
+                'title': 'Paticipantes por recurso',
                 "titlefont": {
                     "size": 23
                 },
@@ -70,71 +135,29 @@ app.layout = html.Div(children=[
         start_date=prueba.events_per_day(prueba.dataframe)['Fecha'].min(),
         end_date=prueba.events_per_day(prueba.dataframe)['Fecha'].max(),
     ),
-    html.Div(
-        children=[
-            html.Div(
-                className='eight columns',
-                children=[
-                    dcc.Graph(
-                        figure={
-                            'data': [
-                                {'labels': ['Participantes', 'No Participantes'],
-                                 'values': [
-                                     prueba.num_participants_nonparticipants(prueba.dataframe,
-                                                                             prueba.dataframe_Usuarios)[
-                                         'Participantes'][0],
-                                     prueba.num_participants_nonparticipants(prueba.dataframe,
-                                                                             prueba.dataframe_Usuarios)[
-                                         'No participantes'][0]], 'type': 'pie',
-                                 'automargin': True,
-                                 'textinfo': 'none'
-                                 },
-                            ],
-                            'layout': {
-                                'title': 'Eventos por recurso',
-                                "titlefont": {
-                                    "size": 23
-                                },
-                                'plot_bgcolor': colors['background'],
-                                'paper_bgcolor': colors['background'],
-                                'font': {
-                                    'color': colors['text']
-                                }
-                            }
-                        }
-                    )],
-            ),
 
-            html.Div(
-                children=[
-                    html.H3(
-                        children='Usuarios no participantes',
-                        style={
-                            'textAlign': 'center',
-                            'color': colors['text'],
-                        }
-                    ),
-                    html.Div(
-                        dash_table.DataTable(
-                            id='table',
-                            columns=[{"name": i, "id": i} for i in
-                                     prueba.list_nonparticipant(prueba.dataframe, prueba.dataframe_Usuarios).columns],
-                            data=prueba.list_nonparticipant(prueba.dataframe, prueba.dataframe_Usuarios).to_dict(
-                                'records'),
-                            style_header={'backgroundColor': colors['background']},
-                            style_cell={'textAlign': 'left',
-                                        'backgroundColor': 'rgb(50, 50, 50)',
-                                        'color': colors['text'],
-                                        },
-                            style_table={
-                                'maxHeight': '200px',
-                                'overflowY': 'scroll'
-                            },
-                        ),
-                    ),
-                ],
-                style={'display': 'inline-block'}, )
-        ], style={'text-align': 'center'}),
+dcc.Graph(
+        id='EventosPorRecurso',
+        figure={
+            'data': [
+                {'x': prueba.events_per_resource(prueba.dataframe)['Número de eventos'],
+                 'y': prueba.events_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation': 'h'},
+            ],
+            'layout': {
+                'title': 'Recursos por número de eventos',
+                "titlefont": {
+                    "size": 23
+                },
+                'yaxis': {'automargin': True},
+                'xaxis': {'automargin': True},
+                'plot_bgcolor': colors['background'],
+                'paper_bgcolor': colors['background'],
+                'font': {
+                    'color': colors['text']
+                }
+            }
+        },
+    ),
 ])
 
 

--- a/EjerciciosLog/PREZv0.0.3.py
+++ b/EjerciciosLog/PREZv0.0.3.py
@@ -4,9 +4,9 @@ import dash_core_components as dcc
 import dash_html_components as html
 import MoodleAnalysisLibrary
 
-prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_G668_1819_20191223-1648.csv",
+prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_BD_20182019_anonymized.csv",
                                                       "C:/Users/sal8b/OneDrive/Escritorio/Beca", "Usuarios.csv",
-                                                      ['0', '323', '231']))
+                                                      ['0','323','231','2']))
 
 app = dash.Dash(__name__)
 

--- a/EjerciciosLog/PREZv0.0.3.py
+++ b/EjerciciosLog/PREZv0.0.3.py
@@ -3,7 +3,7 @@ import dash_table
 import dash_core_components as dcc
 import dash_html_components as html
 import MoodleAnalysisLibrary
-import pandas as pd
+
 
 prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_G668_1819_20191223-1648.csv",
                                                       "C:/Users/sal8b/OneDrive/Escritorio/Beca", "Usuarios.csv",
@@ -160,4 +160,4 @@ def update_output(start_date, end_date):
 
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run_server()

--- a/EjerciciosLog/app.py
+++ b/EjerciciosLog/app.py
@@ -1,19 +1,21 @@
 import pandas as pd
 import MoodleAnalysisLibrary
 
-prueba=(MoodleAnalysisLibrary.MoodleAnalysisLibrary("TestingLog99Rows.csv","", []))
-print(prueba.dataframe['Hora'][77])
-prueba.graphic_events_per_context(prueba.dataframe)
-prueba.graphic_events_per_user(prueba.dataframe)
-ini = pd.Timestamp(2019, 8, 1)
-fin = pd.Timestamp(2019, 8, 29)
+prueba = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("logs_G668_1819_20191223-1648.csv",
+                                                      "C:/Users/sal8b/OneDrive/Escritorio/Beca", "Usuarios.csv",
+                                                      ['0', '323', '231']))
+# prueba.graphic_events_per_context(prueba.dataframe)
+# prueba.graphic_events_per_user(prueba.dataframe)
+# ini = pd.Timestamp(2019, 8, 1)
+# fin = pd.Timestamp(2019, 8, 29)
 
-print(prueba.num_events(prueba.dataframe))
-print(prueba.num_teachers(prueba.dataframe))
-print(prueba.num_participants_per_subject(prueba.dataframe))
-print(prueba.average_events_per_participant(prueba.dataframe))
-print(prueba.events_per_month(prueba.dataframe))
-print(prueba.events_per_week(prueba.dataframe))
-print(prueba.events_per_day(prueba.dataframe))
-print(prueba.events_per_resource(prueba.dataframe))
-print(prueba.events_per_hour(prueba.dataframe))
+# print(prueba.num_events(prueba.dataframe))
+# print(prueba.num_teachers(prueba.dataframe))
+# print(prueba.num_participants_per_subject(prueba.dataframe))
+# print(prueba.average_events_per_participant(prueba.dataframe))
+# print(prueba.events_per_month(prueba.dataframe))
+# print(prueba.events_per_week(prueba.dataframe))
+# print(prueba.events_per_day(prueba.dataframe))
+# print(prueba.events_per_resource(prueba.dataframe))
+# print(prueba.events_per_hour(prueba.dataframe))
+print(prueba.participants_per_resource(prueba.dataframe))

--- a/EjerciciosLog/test_moodleAnalysisLibrary.py
+++ b/EjerciciosLog/test_moodleAnalysisLibrary.py
@@ -152,6 +152,27 @@ class TestMoodleAnalysisLibrary(unittest.TestCase):
         self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-09']['Número de eventos'].to_string(index=False), " 3")
         self.assertEqual(len(dataframe), 1)
 
+    def test_participants_per_resource(self):
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0]['Número de participantes'], 13)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0]['Recurso'], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1]['Número de participantes'], 2)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1]['Recurso'], "Carpeta: Recursos del Alumnado")
+
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2]['Número de participantes'], 1)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2]['Recurso'], "Carpeta: Entrega inicial")
+
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3]['Número de participantes'], 1)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3]['Recurso'], "Carpeta: Exámenes")
+
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4]['Número de participantes'], 1)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4]['Recurso'], "Carpeta: Papeleo")
+
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5]['Número de participantes'], 1)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5]['Recurso'], "Foro: Noticias de clase")
+
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6]['Número de participantes'], 1)
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6]['Recurso'], "Tarea: Entrega inicial")
 
 
     def test_eventsPerHour(self):


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de la historia de usuario de esta rama era proporcionar al usuario un indicador del número total de participantes por recurso. Esto permitirá conocer cuántos de los participantes han usado cada recurso de Moodle.

Para ello, se optó por un gráfico de barras con el número de participante en el eje de las ordenadas y los recursos en el de las abscisas. Estos recursos se han ordenado según el número de interacciones para que así puedan ubicarse rápidamente según el uso que se les da.

Esto se llevó a cabo en una función denominada _participants_per_resource_, que no generó problema alguno. Para el tratamiento de la interfaz gráfica se añadió un gráfico de barras con orienzación horizontal y los ejes invertidos, para solventar el problema de las etiquetas. Sin embargo, surgió otro problema, tal gráfica cortaba el gráfico que tenía encima. Esto era porque según el código, tal gráfica interpretaba que lo que tenía encima era una dash table y configuraba su altura con respecto a ella. Para solucionarlo, se optó por intercambiar la posición de la gráfica cortada y la tabla. Para que la tabla recién incorporada tomase como referencia a la otra gráfica y no a la tabla.

En esta historia también se aprovechó para reordenar los elementos en la interfaz para seguir un orden más lógico.

Tras la implementación del código (_participants_per_resource_ en _MoodleAnalysisLibrary_) y de la interfaz (prez) en las que se fueron ejecutando pruebas de aceptación sobre datos reales. Se pasó, para unas pruebas más de grano fino, a las pruebas unitarias sobre datos anonimizados. Estas pruebas fueron ejecutadas satisfactoriamente y pueden encontrarse en _test_moodleAnalysisLibrary_.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.