### PR TITLE
Us380181 establecer constantes

### DIFF
--- a/EjerciciosLog/MoodleAnalysisLibrary.py
+++ b/EjerciciosLog/MoodleAnalysisLibrary.py
@@ -1,10 +1,15 @@
 import os
 import pandas as pd
 
-CONTEXTO = 'Contexto del evento'
 ID_USUARIO = 'IDUsuario'
 NOMBRE_USUARIO = 'Nombre completo del usuario'
-
+NUM_PARTICIPANTES = 'Número de participantes'
+DESCRIPCION = 'Descripción'
+FECHA_HORA = 'Hora'
+CONTEXTO = 'Contexto del evento'
+NUM_EVENTOS = 'Número de eventos'
+NO_PARTICIPANTES = 'No participantes'
+PARTICIPANTES = 'Participantes'
 
 class MoodleAnalysisLibrary():
     dataframe = pd.DataFrame
@@ -21,7 +26,7 @@ class MoodleAnalysisLibrary():
         self.dataframe = self.dataframe[~self.dataframe[NOMBRE_USUARIO].isin(['-'])]
         self.dataframe=MoodleAnalysisLibrary.change_hora_type(self.dataframe)
         self.dataframe=MoodleAnalysisLibrary.add_mont_day_hour_columns(self, self.dataframe)
-        self.dataframe = self.dataframe.sort_values(by=['Hora'])
+        self.dataframe = self.dataframe.sort_values(by=[FECHA_HORA])
         self.dataframe_usuarios = pd.read_csv(usuarioscsv)
 
     def create_data_frame(self, name, path) -> pd.DataFrame:
@@ -83,7 +88,7 @@ class MoodleAnalysisLibrary():
             Log con la columna añadida.
 
         """
-        dataframe[(ID_USUARIO)] = dataframe['Descripción'].str.extract('[i][d]\s\'(\d*)\'', expand=True) #NÚMEROS NEGATIVOS
+        dataframe[(ID_USUARIO)] = dataframe[DESCRIPCION].str.extract('[i][d]\s\'(\d*)\'', expand=True) #NÚMEROS NEGATIVOS
         return dataframe
 
     def delete_columns(self, dataframe, columns) -> pd.DataFrame:
@@ -187,7 +192,7 @@ class MoodleAnalysisLibrary():
             Log con la columna Hora cambiada.
 
         """
-        dataframe['Hora'] = pd.to_datetime(dataframe['Hora'],dayfirst=True)
+        dataframe[FECHA_HORA] = pd.to_datetime(dataframe[FECHA_HORA],dayfirst=True)
         return dataframe
 
     def between_dates(self, dataframe, initial, final):
@@ -211,7 +216,7 @@ class MoodleAnalysisLibrary():
             Log con los eventos comprendidos.
 
         """
-        result = (dataframe['Hora'] > initial) & (dataframe['Hora'] <= final)
+        result = (dataframe[FECHA_HORA] > initial) & (dataframe[FECHA_HORA] <= final)
         dataframe = dataframe.loc[result]
         return dataframe
 
@@ -232,9 +237,9 @@ class MoodleAnalysisLibrary():
             Log con las columnas añadidas.
 
         """
-        dataframe['HoraDelDía'] = pd.DatetimeIndex(dataframe['Hora']).time
-        dataframe['DíaDelMes'] = pd.DatetimeIndex(dataframe['Hora']).day
-        dataframe['MesDelAño'] = pd.DatetimeIndex(dataframe['Hora']).month
+        dataframe['HoraDelDía'] = pd.DatetimeIndex(dataframe[FECHA_HORA]).time
+        dataframe['DíaDelMes'] = pd.DatetimeIndex(dataframe[FECHA_HORA]).day
+        dataframe['MesDelAño'] = pd.DatetimeIndex(dataframe[FECHA_HORA]).month
         return dataframe
 
     """
@@ -317,12 +322,12 @@ class MoodleAnalysisLibrary():
             participantes.
 
         """
-        data={'Participantes':[0],'No participantes':[0]}
+        data={PARTICIPANTES:[0], NO_PARTICIPANTES:[0]}
         df=pd.DataFrame(data)
-        df['Participantes']=dataframe[ID_USUARIO].nunique()
+        df[PARTICIPANTES]=dataframe[ID_USUARIO].nunique()
         for fila in dataframeusuarios.iterrows():
             if fila[1][NOMBRE_USUARIO] not in dataframe[NOMBRE_USUARIO].values:
-                df['No participantes']=df['No participantes']+1
+                df[NO_PARTICIPANTES]= df[NO_PARTICIPANTES] + 1
         return df
 
     def list_nonparticipant(self, dataframe, dataframeusuarios):
@@ -372,8 +377,8 @@ class MoodleAnalysisLibrary():
             Lista con los participantes y su número de participantes.
 
         """
-        result = pd.DataFrame({'Número de eventos': dataframe.groupby([NOMBRE_USUARIO, ID_USUARIO]).size()}).reset_index()
-        result = result.sort_values(by=['Número de eventos'])
+        result = pd.DataFrame({NUM_EVENTOS: dataframe.groupby([NOMBRE_USUARIO, ID_USUARIO]).size()}).reset_index()
+        result = result.sort_values(by=[NUM_EVENTOS])
         return result
 
     def events_per_month(self, dataframe):
@@ -394,8 +399,8 @@ class MoodleAnalysisLibrary():
 
         """
         result = 0
-        result = dataframe['Hora'].groupby(dataframe.Hora.dt.strftime('%Y-%m')).agg('count') + result
-        resultdf = pd.DataFrame(data=result.values, index=result.index, columns=["Número de eventos"])
+        result = dataframe[FECHA_HORA].groupby(dataframe.Hora.dt.strftime('%Y-%m')).agg('count') + result
+        resultdf = pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS])
         resultdf['Fecha'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         return resultdf
@@ -418,8 +423,8 @@ class MoodleAnalysisLibrary():
 
         """
         result = 0
-        result = dataframe['Hora'].groupby(dataframe.Hora.dt.strftime('%W')).agg('count') + result
-        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=["Número de eventos"]))
+        result = dataframe[FECHA_HORA].groupby(dataframe.Hora.dt.strftime('%W')).agg('count') + result
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf['Fecha'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         return resultdf
@@ -442,8 +447,8 @@ class MoodleAnalysisLibrary():
 
         """
         result = 0
-        result = dataframe['Hora'].groupby(dataframe.Hora.dt.strftime('%Y-%m-%d')).agg('count') + result
-        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=["Número de eventos"]))
+        result = dataframe[FECHA_HORA].groupby(dataframe.Hora.dt.strftime('%Y-%m-%d')).agg('count') + result
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf['Fecha'] = resultdf.index
         resultdf['Fecha'] = pd.to_datetime(resultdf['Fecha'])
         resultdf.reset_index(drop=True, inplace=True)
@@ -469,10 +474,10 @@ class MoodleAnalysisLibrary():
         """
         result = 0
         result = dataframe[CONTEXTO].groupby(dataframe[CONTEXTO]).agg('count') + result
-        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=['Número de eventos']))
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf['Recurso'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
-        resultdf = resultdf.sort_values(ascending=False,by=['Número de eventos'])
+        resultdf = resultdf.sort_values(ascending=False,by=[NUM_EVENTOS])
         return resultdf
 
     def participants_per_resource(self, dataframe):
@@ -493,10 +498,10 @@ class MoodleAnalysisLibrary():
 
         """
         result = dataframe.groupby(CONTEXTO)[ID_USUARIO].nunique()
-        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=['Número de participantes']))
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_PARTICIPANTES]))
         resultdf['Recurso'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
-        resultdf = resultdf.sort_values(ascending=False, by=['Número de participantes'])
+        resultdf = resultdf.sort_values(ascending=False, by=[NUM_PARTICIPANTES])
         return resultdf
 
     def events_per_hour(self, dataframe):
@@ -517,9 +522,9 @@ class MoodleAnalysisLibrary():
 
         """
         result = 0
-        result = dataframe['Hora'].groupby((dataframe.Hora.dt.strftime('%H'))).agg('count') + result
-        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=["Número de eventos"]))
-        resultdf['Hora'] = resultdf.index
+        result = dataframe[FECHA_HORA].groupby((dataframe.Hora.dt.strftime('%H'))).agg('count') + result
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
+        resultdf[FECHA_HORA] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         return resultdf
 
@@ -545,7 +550,7 @@ class MoodleAnalysisLibrary():
 
         """
         resultdf = MoodleAnalysisLibrary.events_per_resource(self, dataframe)
-        result2 = (resultdf['Número de eventos'] > min) & (resultdf['Número de eventos'] <= max)
+        result2 = (resultdf[NUM_EVENTOS] > min) & (resultdf[NUM_EVENTOS] <= max)
         resultdf = resultdf.loc[result2]
         return resultdf
 

--- a/EjerciciosLog/prez.py
+++ b/EjerciciosLog/prez.py
@@ -120,8 +120,8 @@ app.layout = html.Div(children=[
         id='ParticipantesPorRecurso',
         figure={
             'data': [
-                {'x': prueba.events_per_resource(prueba.dataframe)[NUM_EVENTOS],
-                 'y': prueba.events_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation': 'h'},
+                {'x': prueba.participants_per_resource(prueba.dataframe)['Número de participantes'],
+                 'y': prueba.participants_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation': 'h'},
             ],
             'layout': {
                 'title': 'Paticipantes por recurso',

--- a/EjerciciosLog/prez.py
+++ b/EjerciciosLog/prez.py
@@ -6,6 +6,11 @@ import dash_table
 import os
 import sys
 
+RECURSO = 'Recurso'
+FECHA = 'Fecha'
+NUM_PARTICIPANTES = 'Número de participantes'
+NO_PARTICIPANTES = 'No participantes'
+PARTICIPANTES = 'Participantes'
 NUM_EVENTOS = 'Número de eventos'
 
 log=input("Introduza el nombre del fichero log, no olvides el .csv ")
@@ -88,14 +93,14 @@ app.layout = html.Div(children=[
                         id='pie-chart-participants-users',
                         figure={
                             'data': [
-                                {'labels': ['Participantes', 'No Participantes'],
+                                {'labels': [PARTICIPANTES, NO_PARTICIPANTES],
                                  'values': [
                                      prueba.num_participants_nonparticipants(prueba.dataframe,
                                                                              prueba.dataframe_usuarios)[
-                                         'Participantes'][0],
+                                         PARTICIPANTES][0],
                                      prueba.num_participants_nonparticipants(prueba.dataframe,
                                                                              prueba.dataframe_usuarios)[
-                                         'No participantes'][0]], 'type': 'pie',
+                                         NO_PARTICIPANTES][0]], 'type': 'pie',
                                  'automargin': True,
                                  'textinfo': 'none'
                                  },
@@ -120,11 +125,11 @@ app.layout = html.Div(children=[
         id='ParticipantesPorRecurso',
         figure={
             'data': [
-                {'x': prueba.participants_per_resource(prueba.dataframe)['Número de participantes'],
-                 'y': prueba.participants_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation': 'h'},
+                {'x': prueba.participants_per_resource(prueba.dataframe)[NUM_PARTICIPANTES],
+                 'y': prueba.participants_per_resource(prueba.dataframe)[RECURSO], 'type': 'bar', 'orientation': 'h'},
             ],
             'layout': {
-                'title': 'Paticipantes por recurso',
+                'title': 'Participantes por recurso',
                 "titlefont": {
                     "size": 23
                 },
@@ -150,10 +155,10 @@ app.layout = html.Div(children=[
                 id='my-date-picker-range',
                 display_format='D/M/Y',
                 style={'font-size': '20px'},
-                min_date_allowed=prueba.events_per_day(prueba.dataframe)['Fecha'].min(),
-                max_date_allowed=prueba.events_per_day(prueba.dataframe)['Fecha'].max(),
-                start_date=prueba.events_per_day(prueba.dataframe)['Fecha'].min(),
-                end_date=prueba.events_per_day(prueba.dataframe)['Fecha'].max(),
+                min_date_allowed=prueba.events_per_day(prueba.dataframe)[FECHA].min(),
+                max_date_allowed=prueba.events_per_day(prueba.dataframe)[FECHA].max(),
+                start_date=prueba.events_per_day(prueba.dataframe)[FECHA].min(),
+                end_date=prueba.events_per_day(prueba.dataframe)[FECHA].max(),
             ),
             dcc.Graph(id='graph-events-per-day-students'),
         ],style={'background': colors['grey']}
@@ -164,7 +169,7 @@ dcc.Graph(
         figure={
             'data': [
                 {'x': prueba.events_per_resource(prueba.dataframe)[NUM_EVENTOS],
-                 'y': prueba.events_per_resource(prueba.dataframe)['Recurso'], 'type': 'bar', 'orientation': 'h'},
+                 'y': prueba.events_per_resource(prueba.dataframe)[RECURSO], 'type': 'bar', 'orientation': 'h'},
             ],
             'layout': {
                 'title': 'Recursos por número de eventos',
@@ -192,7 +197,7 @@ def update_output(start_date, end_date):
     dfaux5 = prueba.events_between_dates(prueba.dataframe, start_date, end_date, True)
     return {
         'data': [
-            {'x': dfaux5['Fecha'], 'y': dfaux5[NUM_EVENTOS], 'type': 'scatter'},
+            {'x': dfaux5[FECHA], 'y': dfaux5[NUM_EVENTOS], 'type': 'scatter'},
         ],
         'layout': {
             'title': 'Eventos por rango de días',

--- a/EjerciciosLog/test_moodleAnalysisLibrary.py
+++ b/EjerciciosLog/test_moodleAnalysisLibrary.py
@@ -3,10 +3,19 @@ import MoodleAnalysisLibrary
 import pandas as pd
 import numpy as np
 
+FECHA = 'Fecha'
+
+NO_PARTICIPANTES = 'No participantes'
+
+PARTICIPANTES = 'Participantes'
+
+RECURSO = 'Recurso'
+NOMBRE_USUARIO = 'Nombre completo del usuario'
 NUM_EVENTOS = 'Número de eventos'
-
+FECHA_HORA = 'Hora'
+DESCRIPCION = 'Descripción'
+ID_USUARIO = 'IDUsuario'
 NUM_PARTICIPANTES = 'Número de participantes'
-
 NUM_EVENTOS = 'Número de eventos'
 
 prueba1Rows = (MoodleAnalysisLibrary.MoodleAnalysisLibrary("TestingLog1Row.csv","","UsuariosTest.csv", []))
@@ -28,25 +37,25 @@ class TestMoodleAnalysisLibrary(unittest.TestCase):
 
     def test_addIDColumn(self):
         dataframe=prueba1Rows.add_ID_column(prueba1Rows.dataframe) #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
-        self.assertTrue('IDUsuario' in dataframe.columns)
+        self.assertTrue(ID_USUARIO in dataframe.columns)
         dataframe=prueba99Rows.add_ID_column(prueba1Rows.dataframe) #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
-        self.assertTrue('IDUsuario' in dataframe.columns)
+        self.assertTrue(ID_USUARIO in dataframe.columns)
 
     def test_deleteColumns(self):
-        dataframe=prueba1Rows.delete_columns(prueba1Rows.dataframe, ['Descripción'])
-        self.assertFalse('Descripción' in dataframe.columns)
+        dataframe=prueba1Rows.delete_columns(prueba1Rows.dataframe, [DESCRIPCION])
+        self.assertFalse(DESCRIPCION in dataframe.columns)
 
     def test_deleteByID(self):
         dataframe=prueba1Rows.dataframe
-        self.assertTrue("0" in dataframe['IDUsuario'].values)
+        self.assertTrue("0" in dataframe[ID_USUARIO].values)
         dataframe=prueba1Rows.delete_by_ID(prueba1Rows.dataframe, ["0"])
-        self.assertTrue("0" not in dataframe['IDUsuario'].values)
+        self.assertTrue("0" not in dataframe[ID_USUARIO].values)
 
     def test_changeHoraType(self):
         dataframe=prueba1Rows.dataframe
-        self.assertEqual(dataframe['Hora'].dtype,'datetime64[ns]')# Se hace en el constructor
+        self.assertEqual(dataframe[FECHA_HORA].dtype, 'datetime64[ns]')# Se hace en el constructor
         dataframe=prueba99Rows.dataframe
-        self.assertEqual(dataframe['Hora'].dtype,'datetime64[ns]')# Se hace en el constructor
+        self.assertEqual(dataframe[FECHA_HORA].dtype, 'datetime64[ns]')# Se hace en el constructor
 
     def test_betweenDates(self):
         ini = np.datetime64('2019-08-01')
@@ -82,22 +91,30 @@ class TestMoodleAnalysisLibrary(unittest.TestCase):
 
 
     def test_numEventsPerParticipant(self):
-        self.assertTrue((((prueba1Rows.num_events_per_participant(prueba1Rows.dataframe))['Número de eventos'][0]) == 1))
+        self.assertTrue((((prueba1Rows.num_events_per_participant(prueba1Rows.dataframe))[NUM_EVENTOS][0]) == 1))
 
     def test_num_participants_nonparticipants(self):
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))['Participantes'][0]==13)
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))['No participantes'][0]==4)
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+                            PARTICIPANTES][0] == 13)
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+                            NO_PARTICIPANTES][0] == 4)
 
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99RowsSinUsuarios.dataframe,prueba99RowsSinUsuarios.dataframe_usuarios))['Participantes'][0]==13)
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99RowsSinUsuarios.dataframe,prueba99RowsSinUsuarios.dataframe_usuarios))['No participantes'][0]==0)
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99RowsSinUsuarios.dataframe,prueba99RowsSinUsuarios.dataframe_usuarios))[
+                            PARTICIPANTES][0] == 13)
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99RowsSinUsuarios.dataframe,prueba99RowsSinUsuarios.dataframe_usuarios))[
+                            NO_PARTICIPANTES][0] == 0)
 
 
 
     def test_list_nonparticipant(self):
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))['Nombre completo del usuario'][0]=='Sanchez Barreiro, Pablo')
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))['Nombre completo del usuario'][1]=='Pedro')
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))['Nombre completo del usuario'][2]=='JAVI')
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))['Nombre completo del usuario'][3]=='RODRIGUEZ PÉREZ, DANIEL')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+                            NOMBRE_USUARIO][0] == 'Sanchez Barreiro, Pablo')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+                            NOMBRE_USUARIO][1] == 'Pedro')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+                            NOMBRE_USUARIO][2] == 'JAVI')
+        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+                            NOMBRE_USUARIO][3] == 'RODRIGUEZ PÉREZ, DANIEL')
 
 
         self.assertTrue('TODOS HAN PARTICIPADO' in (prueba99Rows.list_nonparticipant(prueba99RowsSinUsuarios.dataframe, prueba99RowsSinUsuarios.dataframe_usuarios).columns))
@@ -114,78 +131,78 @@ class TestMoodleAnalysisLibrary(unittest.TestCase):
 
     def test_eventsPerResource(self):
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[0][NUM_EVENTOS], 32)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[0]['Recurso'], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[1][NUM_EVENTOS], 13)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[1]['Recurso'], "Foro: Noticias de clase")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[1][RECURSO], "Foro: Noticias de clase")
 
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[2][NUM_EVENTOS], 4)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[2]['Recurso'], "Carpeta: Recursos del Alumnado")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[2][RECURSO], "Carpeta: Recursos del Alumnado")
 
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[3][NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[3]['Recurso'], "Carpeta: Entrega inicial")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[3][RECURSO], "Carpeta: Entrega inicial")
 
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[4][NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[4]['Recurso'], "Carpeta: Exámenes")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[4][RECURSO], "Carpeta: Exámenes")
 
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[5][NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[5]['Recurso'], "Carpeta: Papeleo")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[5][RECURSO], "Carpeta: Papeleo")
 
         self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[6][NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[6]['Recurso'], "Tarea: Entrega inicial")
+        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[6][RECURSO], "Tarea: Entrega inicial")
 
         self.assertEqual(prueba1Rows.events_per_resource(prueba1Rows.dataframe).iloc[0][NUM_EVENTOS], 1)
-        self.assertEqual(prueba1Rows.events_per_resource(prueba1Rows.dataframe).iloc[0]['Recurso'], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba1Rows.events_per_resource(prueba1Rows.dataframe).iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
     def test_events_between_dates(self):
         ini = np.datetime64('2019-08-01')
         fin = np.datetime64('2019-08-29')
         dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin)
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-08-01'][NUM_EVENTOS].to_string(index=False), " 1")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-08-01'][NUM_EVENTOS].to_string(index=False), " 1")
         ini = np.datetime64('2019-09-01')
         fin = np.datetime64('2019-09-10')
         dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin)
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-09'][NUM_EVENTOS].to_string(index=False), " 3")
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-05'][NUM_EVENTOS].to_string(index=False), " 1")
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-02'][NUM_EVENTOS].to_string(index=False), " 1")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][NUM_EVENTOS].to_string(index=False), " 3")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-05'][NUM_EVENTOS].to_string(index=False), " 1")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-02'][NUM_EVENTOS].to_string(index=False), " 1")
         ini = np.datetime64('2019-09-09')
         fin = np.datetime64('2019-09-23')
         dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin)
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-09'][NUM_EVENTOS].to_string(index=False), " 3")
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-22'][NUM_EVENTOS].to_string(index=False), " 4")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][NUM_EVENTOS].to_string(index=False), " 3")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-22'][NUM_EVENTOS].to_string(index=False), " 4")
         self.assertEqual(len(dataframe), 2)
         dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin,True)
-        self.assertEqual(dataframe.loc[dataframe['Fecha'] == '2019-09-09'][NUM_EVENTOS].to_string(index=False), " 3")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][NUM_EVENTOS].to_string(index=False), " 3")
         self.assertEqual(len(dataframe), 1)
 
     def test_participants_per_resource(self):
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0][
                              NUM_PARTICIPANTES], 13)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0]['Recurso'], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1][
                              NUM_PARTICIPANTES], 2)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1]['Recurso'], "Carpeta: Recursos del Alumnado")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1][RECURSO], "Carpeta: Recursos del Alumnado")
 
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2][
                              NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2]['Recurso'], "Carpeta: Entrega inicial")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2][RECURSO], "Carpeta: Entrega inicial")
 
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3][
                              NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3]['Recurso'], "Carpeta: Exámenes")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3][RECURSO], "Carpeta: Exámenes")
 
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4][
                              NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4]['Recurso'], "Carpeta: Papeleo")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4][RECURSO], "Carpeta: Papeleo")
 
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5][
                              NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5]['Recurso'], "Foro: Noticias de clase")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5][RECURSO], "Foro: Noticias de clase")
 
         self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6][
                              NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6]['Recurso'], "Tarea: Entrega inicial")
+        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6][RECURSO], "Tarea: Entrega inicial")
 
 
     def test_eventsPerHour(self):


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era solucionar una serie de Code Smells que estaban empeorando la calidad del código y que estaban siendo arrastrados desde el primer Sprint. Estos Code Smells se producían por el uso repetido de literales para hacer referencia a las columnas de los logs de cursos de Moodle. Estos Code Smells se han solucionado sustituyendo estos literales por constantes, reduciendo notablemente la deuda técnica del proyecto. Tales sustituciones se han realizado tanto en Prez.py como en Maadle.py como en Test.Maadle.py.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.