### PR TITLE
Us383066 estilo date picker range

### DIFF
--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -152,6 +152,7 @@ app.layout = html.Div(children=[
                 id='my-date-picker-range',
                 display_format='D/M/Y',
                 style={'font-size': '20px'},
+                first_day_of_week=1,
                 min_date_allowed=prueba.events_per_day(prueba.dataframe)[FECHA].min(),
                 max_date_allowed=prueba.events_per_day(prueba.dataframe)[FECHA].max(),
                 start_date=prueba.events_per_day(prueba.dataframe)[FECHA].min(),

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -29,7 +29,7 @@ def find_data_file(filename):
     if getattr(sys, 'frozen', False):
         datadir = os.path.dirname(sys.executable)
     else:
-        datadir = os.path.dirname("C:/Users/sal8b/OneDrive/Escritorio/Despliegue/assets")
+        datadir = os.path.dirname("C:/Users/sal8b/OneDrive/Escritorio/LibreriaMoodleAnalisis/EjerciciosLog/assets")
         print(datadir)
     return os.path.join(datadir, filename)
 

--- a/EjerciciosLog/assets/style.css
+++ b/EjerciciosLog/assets/style.css
@@ -474,3 +474,10 @@ there.
     border-spacing: 0;
     border: 1px solid #e4e7e7;
 }
+.DateInput_fangShape {
+    fill: black;
+}
+.DateInput_fangStroke {
+    stroke: black;
+    fill: transparent;
+}

--- a/EjerciciosLog/assets/style.css
+++ b/EjerciciosLog/assets/style.css
@@ -249,7 +249,8 @@ textarea,
 select {
   height: 38px;
   padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
-  background-color: #fff;
+  background-color: #111111;
+  color: #7FDBFF;
   border: 1px solid #D1D1D1;
   border-radius: 4px;
   box-shadow: none;
@@ -416,3 +417,60 @@ there.
 
 /* Larger than Desktop HD */
 @media (min-width: 1200px) {}
+
+
+/* Calendar */
+.DateRangePickerInput {
+    background-color: black;
+    display: inline-block;
+}
+.CalendarMonth {
+    background: black;
+    text-align: center;
+    vertical-align: top;
+}
+.DayPickerNavigation_button__default {
+    border: 1px solid #e4e7e7;
+    background-color: black;
+    color: #757575;
+}
+.DayPicker_transitionContainer {
+    position: relative;
+    overflow: hidden;
+    border-radius: 3px;
+    background: black;
+}
+.CalendarMonthGrid {
+    background: black;
+    text-align: left;
+    z-index: 0;
+}
+.CalendarDay__blocked_out_of_range, .CalendarDay__blocked_out_of_range:active, .CalendarDay__blocked_out_of_range:hover {
+    background: gray;
+    border: 1px solid #e4e7e7;
+    color: #cacccd;
+}
+.DayPicker_weekHeader {
+    color: #7FDBFF;
+    text-align: left;
+}
+.CalendarMonth_caption {
+    color: #7FDBFF;
+    font-size: 18px;
+    text-align: center;
+    caption-side: initial;
+}
+.DayPickerNavigation_svg__horizontal {
+    height: 19px;
+    width: 19px;
+    fill: white;
+    display: block;
+}
+.DayPicker__horizontal {
+    background: black;
+}
+.CalendarMonth_table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    border: 1px solid #e4e7e7;
+}


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era adaptar el estilo del date picker range al del resto de la web. Por el momento, la web tenía tonos oscuros y azules a excepción del date picker range, el propio botón y el calendario desplegado. Esto desentonaba bastante así que decidió adaptarse cambiando sus colores.

De esta forma, se añadieron ciertas personalizaciones en el style.css del proyecto. En concreto son 13 los elementos que tuvieron que cambiarse para que su apariencia estuviese en concordancia. Además, se utilizó este ticket para cambiar el calendario, y elegir el lunes como el primer día de la semana. También se cambió el literal que indicaba la ruta del css, pues la que figuraba estaba anticuada.

Tras esto, se pasaron las pruebas de aceptación, comprobando que efecitvamente se ajustaba a lo planeado.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.