### PR TITLE
Us382371 refactorización no estáticos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - "pip install matplotlib"
   - "pip install pandas"
   - "pip install xlrd"
+  - "pip install openpyxl"
   - "cd EjerciciosLog"
   - "python -m unittest"
   - "pip install coverage"

--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -11,27 +11,23 @@ NUM_EVENTOS = 'Número de eventos'
 NO_PARTICIPANTES = 'No participantes'
 PARTICIPANTES = 'Participantes'
 
-class Maadle():
+
+class Maadle:
     dataframe = pd.DataFrame
     teachers = []
     dataframe_usuarios = pd.DataFrame
-    dataframe_recursos = pd.DataFrame
     def __init__(self, name, path, usuariosxls, userstodelete):
-        if path!="":
-            self.dataframe=Maadle.create_data_frame(self, name, path)
+
+        if path != "":
+            self.dataframe = Maadle.create_data_frame(self, name, path)
         else:
-            self.dataframe=Maadle.create_data_frame_file_fame(self, name)
-        self.dataframe=Maadle.add_ID_column(self, self.dataframe)
+            self.dataframe = Maadle.create_data_frame_file_fame(self, name)
+        self.dataframe = Maadle.add_ID_column(self)
         self.teachers = userstodelete
         self.dataframe = self.dataframe[~self.dataframe[NOMBRE_USUARIO].isin(['-'])]
-        self.dataframe=Maadle.change_hora_type(self.dataframe)
-        self.dataframe=Maadle.add_mont_day_hour_columns(self, self.dataframe)
+        self.dataframe = Maadle.change_hora_type(self)
+        self.dataframe = Maadle.add_mont_day_hour_columns(self)
         self.dataframe = self.dataframe.sort_values(by=[FECHA_HORA])
-        self.dataframe_usuarios = pd.DataFrame(self.dataframe[NOMBRE_USUARIO].unique(),columns =[NOMBRE_USUARIO])
-        self.dataframe_recursos = pd.DataFrame(self.dataframe[CONTEXTO].unique(),columns =[CONTEXTO])
-        with pd.ExcelWriter('ConfigPrez.xlsx') as writer:
-            self.dataframe_usuarios.to_excel(writer, sheet_name='Usuarios', index=False)
-            self.dataframe_recursos.to_excel(writer, sheet_name='Recursos', index=False)
         self.dataframe_usuarios = pd.read_excel(usuariosxls, sheet_name='Usuarios')
 
     def create_data_frame(self, name, path) -> pd.DataFrame:
@@ -76,7 +72,7 @@ class Maadle():
         """
         return pd.read_csv(name)
 
-    def add_ID_column(self, dataframe) -> pd.DataFrame:
+    def add_ID_column(self) -> pd.DataFrame:
         """
         Summary line.
 
@@ -84,8 +80,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log al que añadir la columna.
 
         Returns
         -------
@@ -93,10 +87,11 @@ class Maadle():
             Log con la columna añadida.
 
         """
-        dataframe[(ID_USUARIO)] = dataframe[DESCRIPCION].str.extract('[i][d]\s\'(\d*)\'', expand=True) #NÚMEROS NEGATIVOS
+        dataframe = self.dataframe
+        dataframe[(ID_USUARIO)] = self.dataframe[DESCRIPCION].str.extract('[i][d]\s\'(\d*)\'', expand=True) #NÚMEROS NEGATIVOS
         return dataframe
 
-    def delete_columns(self, dataframe, columns) -> pd.DataFrame:
+    def delete_columns(self, columns) -> pd.DataFrame:
         """
         Summary line.
 
@@ -104,8 +99,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log del que eliminar las columnas.
         columns : array
             Columnas que eliminar.
 
@@ -115,10 +108,10 @@ class Maadle():
             Log con las columnas eliminadas.
 
         """
-        dataframe = dataframe.drop(columns, axis='columns')
+        dataframe = self.dataframe.drop(columns, axis='columns')
         return dataframe
 
-    def delete_by_ID(self, dataframe, idList) -> pd.DataFrame:
+    def delete_by_ID(self, idList) -> pd.DataFrame:
         """
         Summary line.
 
@@ -126,8 +119,7 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log del que eliminar los usuarios.
+
         idList : array
             Usuarios que eliminar.
 
@@ -138,11 +130,10 @@ class Maadle():
 
         """
         for ele in idList:
-            dataframe = dataframe[~dataframe[ID_USUARIO].isin([ele])]
+            dataframe = self.dataframe[~self.dataframe[ID_USUARIO].isin([ele])]
         return dataframe
 
-
-    def graphic_events_per_user(self, dataframe):
+    def graphic_events_per_user(self):
         """
         Summary line.
 
@@ -150,18 +141,16 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log del que hacer la gráfica.
 
         Returns
         -------
 
 
         """
-        groups = dataframe.groupby([ID_USUARIO]).size()
+        groups = self.dataframe.groupby([ID_USUARIO]).size()
         groups.plot.bar()
 
-    def graphic_events_per_context(self, dataframe):
+    def graphic_events_per_context(self):
         """
         Summary line.
 
@@ -169,18 +158,16 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log del que hacer la gráfica.
 
         Returns
         -------
 
 
         """
-        groups = dataframe.groupby([(CONTEXTO)]).size()
+        groups = self.dataframe.groupby([(CONTEXTO)]).size
         groups.plot.bar()
 
-    def change_hora_type(dataframe):
+    def change_hora_type(self):
         """
         Summary line.
 
@@ -188,8 +175,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log cuya columna quiere ser cambiada de tipo.
 
         Returns
         -------
@@ -197,10 +182,11 @@ class Maadle():
             Log con la columna Hora cambiada.
 
         """
-        dataframe[FECHA_HORA] = pd.to_datetime(dataframe[FECHA_HORA],dayfirst=True)
+        dataframe = self.dataframe
+        dataframe[FECHA_HORA] = pd.to_datetime(self.dataframe[FECHA_HORA], dayfirst=True)
         return dataframe
 
-    def between_dates(self, dataframe, initial, final):
+    def between_dates(self, initial, final):
         """
         Summary line.
 
@@ -208,8 +194,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log cuya columna quiere ser cambiada de tipo.
         initial : Timestamp
             Fecha inicial.
         final : Timestamp
@@ -221,11 +205,11 @@ class Maadle():
             Log con los eventos comprendidos.
 
         """
-        result = (dataframe[FECHA_HORA] > initial) & (dataframe[FECHA_HORA] <= final)
-        dataframe = dataframe.loc[result]
+        result = (self.dataframe[FECHA_HORA] > initial) & (self.dataframe[FECHA_HORA] <= final)
+        dataframe = self.dataframe.loc[result]
         return dataframe
 
-    def add_mont_day_hour_columns(self, dataframe):
+    def add_mont_day_hour_columns(self):
         """
         Summary line.
 
@@ -233,8 +217,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log al que añadir columnas.
 
         Returns
         -------
@@ -242,9 +224,10 @@ class Maadle():
             Log con las columnas añadidas.
 
         """
-        dataframe['HoraDelDía'] = pd.DatetimeIndex(dataframe[FECHA_HORA]).time
-        dataframe['DíaDelMes'] = pd.DatetimeIndex(dataframe[FECHA_HORA]).day
-        dataframe['MesDelAño'] = pd.DatetimeIndex(dataframe[FECHA_HORA]).month
+        dataframe = self.dataframe
+        dataframe['HoraDelDía'] = pd.DatetimeIndex(self.dataframe[FECHA_HORA]).time
+        dataframe['DíaDelMes'] = pd.DatetimeIndex(self.dataframe[FECHA_HORA]).day
+        dataframe['MesDelAño'] = pd.DatetimeIndex(self.dataframe[FECHA_HORA]).month
         return dataframe
 
     """
@@ -256,7 +239,7 @@ class Maadle():
         return dataframe
     """
 
-    def num_events(self, dataframe):
+    def num_events(self):
         """
         Summary line.
 
@@ -264,8 +247,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que contar los eventos.
 
         Returns
         -------
@@ -273,21 +254,22 @@ class Maadle():
             Número de eventos en el log.
 
         """
-        return len(dataframe)
+        return len(self.dataframe)
+
     """"
     Retorna el número de profesores de un dataframe. ***PASARÁ A SER BORRADO
 
     Recibe como parámetro el dataframe.
     Retorna el número de profesores del dataframe.
     """""
-    def num_teachers(self, dataframe):
+    def num_teachers(self):
         result = 0
-        for d in dataframe[NOMBRE_USUARIO].unique():
-            if (d.isupper() == False and d != '-'):
+        for d in self.dataframe[NOMBRE_USUARIO].unique():
+            if d.isupper() == False and d != '-':
                 result = result + 1
         return result
 
-    def num_participants_per_subject(self, dataframe):
+    def num_participants_per_subject(self):
         """
         Summary line.
 
@@ -295,8 +277,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que contar los participantes.
 
         Returns
         -------
@@ -304,9 +284,9 @@ class Maadle():
             Número de participantes en el log.
 
         """
-        return (dataframe[ID_USUARIO].nunique() - Maadle.num_teachers(self, dataframe))
+        return (self.dataframe[ID_USUARIO].nunique() - Maadle.num_teachers(self))
 
-    def num_participants_nonparticipants(self, dataframe, dataframeusuarios):
+    def num_participants_nonparticipants(self):
         """
         Summary line.
 
@@ -314,11 +294,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que contar los participantes.
-
-        dataframeusuarios : dataframe
-            Dataframe en el que contar todos los usuarios (participantes y no participantes).
 
         Returns
         -------
@@ -329,13 +304,13 @@ class Maadle():
         """
         data={PARTICIPANTES:[0], NO_PARTICIPANTES:[0]}
         df=pd.DataFrame(data)
-        df[PARTICIPANTES]=dataframe[ID_USUARIO].nunique()
-        for fila in dataframeusuarios.iterrows():
-            if fila[1][NOMBRE_USUARIO] not in dataframe[NOMBRE_USUARIO].values:
+        df[PARTICIPANTES]=self.dataframe[ID_USUARIO].nunique()
+        for fila in self.dataframe_usuarios.iterrows():
+            if fila[1][NOMBRE_USUARIO] not in self.dataframe[NOMBRE_USUARIO].values:
                 df[NO_PARTICIPANTES]= df[NO_PARTICIPANTES] + 1
         return df
 
-    def list_nonparticipant(self, dataframe, dataframeusuarios):
+    def list_nonparticipant(self):
         """
         Summary line.
 
@@ -343,11 +318,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que contar los participantes.
-
-        dataframeusuarios : dataframe
-            Dataframe con todos los usuarios (participantes y no participantes).
 
         Returns
         -------
@@ -356,8 +326,8 @@ class Maadle():
 
         """
         result=list()
-        for fila in dataframeusuarios[NOMBRE_USUARIO]:
-            if fila not in dataframe[NOMBRE_USUARIO].values:
+        for fila in self.dataframe_usuarios[NOMBRE_USUARIO]:
+            if fila not in self.dataframe[NOMBRE_USUARIO].values:
                 result.append(fila)
         if(result==[]):
             df = pd.DataFrame(result, columns=['TODOS HAN PARTICIPADO'])
@@ -365,7 +335,7 @@ class Maadle():
         df=pd.DataFrame(result,columns=[NOMBRE_USUARIO])
         return df
 
-    def num_events_per_participant(self, dataframe):
+    def num_events_per_participant(self):
         """
         Summary line.
 
@@ -373,8 +343,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos por participante.
 
         Returns
         -------
@@ -382,11 +350,11 @@ class Maadle():
             Lista con los participantes y su número de participantes.
 
         """
-        result = pd.DataFrame({NUM_EVENTOS: dataframe.groupby([NOMBRE_USUARIO, ID_USUARIO]).size()}).reset_index()
+        result = pd.DataFrame({NUM_EVENTOS: self.dataframe.groupby([NOMBRE_USUARIO, ID_USUARIO]).size()}).reset_index()
         result = result.sort_values(by=[NUM_EVENTOS])
         return result
 
-    def events_per_month(self, dataframe):
+    def events_per_month(self):
         """
         Summary line.
 
@@ -394,8 +362,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos por mes.
 
         Returns
         -------
@@ -404,13 +370,13 @@ class Maadle():
 
         """
         result = 0
-        result = dataframe[FECHA_HORA].groupby(dataframe.Hora.dt.strftime('%Y-%m')).agg('count') + result
+        result = self.dataframe[FECHA_HORA].groupby(self.dataframe.Hora.dt.strftime('%Y-%m')).agg('count') + result
         resultdf = pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS])
         resultdf['Fecha'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         return resultdf
 
-    def events_per_week(self, dataframe):
+    def events_per_week(self):
         """
         Summary line.
 
@@ -418,8 +384,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos por semana.
 
         Returns
         -------
@@ -428,13 +392,13 @@ class Maadle():
 
         """
         result = 0
-        result = dataframe[FECHA_HORA].groupby(dataframe.Hora.dt.strftime('%W')).agg('count') + result
+        result = self.dataframe[FECHA_HORA].groupby(self.dataframe.Hora.dt.strftime('%W')).agg('count') + result
         resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf['Fecha'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         return resultdf
 
-    def events_per_day(self, dataframe):
+    def events_per_day(self):
         """
         Summary line.
 
@@ -442,8 +406,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos por día.
 
         Returns
         -------
@@ -452,7 +414,7 @@ class Maadle():
 
         """
         result = 0
-        result = dataframe[FECHA_HORA].groupby(dataframe.Hora.dt.strftime('%Y-%m-%d')).agg('count') + result
+        result = self.dataframe[FECHA_HORA].groupby(self.dataframe.Hora.dt.strftime('%Y-%m-%d')).agg('count') + result
         resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf['Fecha'] = resultdf.index
         resultdf['Fecha'] = pd.to_datetime(resultdf['Fecha'])
@@ -460,7 +422,7 @@ class Maadle():
         return resultdf
 
 
-    def events_per_resource(self, dataframe):
+    def events_per_resource(self):
         """
         Summary line. SPRINT00
 
@@ -468,8 +430,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos por recurso.
 
         Returns
         -------
@@ -478,14 +438,14 @@ class Maadle():
 
         """
         result = 0
-        result = dataframe[CONTEXTO].groupby(dataframe[CONTEXTO]).agg('count') + result
+        result = self.dataframe[CONTEXTO].groupby(self.dataframe[CONTEXTO]).agg('count') + result
         resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf['Recurso'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         resultdf = resultdf.sort_values(ascending=False,by=[NUM_EVENTOS])
         return resultdf
 
-    def participants_per_resource(self, dataframe):
+    def participants_per_resource(self):
         """
         Summary line. SPRINT02
 
@@ -493,8 +453,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de participantes por recurso.
 
         Returns
         -------
@@ -502,14 +460,14 @@ class Maadle():
             Lista con los recursos y su número de eventos.
 
         """
-        result = dataframe.groupby(CONTEXTO)[ID_USUARIO].nunique()
+        result = self.dataframe.groupby(CONTEXTO)[ID_USUARIO].nunique()
         resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_PARTICIPANTES]))
         resultdf['Recurso'] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         resultdf = resultdf.sort_values(ascending=False, by=[NUM_PARTICIPANTES])
         return resultdf
 
-    def events_per_hour(self, dataframe):
+    def events_per_hour(self):
         """
         Summary line.
 
@@ -517,8 +475,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos por hora.
 
         Returns
         -------
@@ -527,13 +483,13 @@ class Maadle():
 
         """
         result = 0
-        result = dataframe[FECHA_HORA].groupby((dataframe.Hora.dt.strftime('%H'))).agg('count') + result
+        result = self.dataframe[FECHA_HORA].groupby((self.dataframe.Hora.dt.strftime('%H'))).agg('count') + result
         resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
         resultdf[FECHA_HORA] = resultdf.index
         resultdf.reset_index(drop=True, inplace=True)
         return resultdf
 
-    def resources_by_number_of_events(self, dataframe, min, max):
+    def resources_by_number_of_events(self, min, max):
         """
         Summary line.
 
@@ -541,8 +497,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log del que filtrar los eventos.
         min : int
             Límite inferior del rango.
         max : int
@@ -554,12 +508,12 @@ class Maadle():
             Log con los eventos filtrados.
 
         """
-        resultdf = Maadle.events_per_resource(self, dataframe)
+        resultdf = Maadle.events_per_resource(self)
         result2 = (resultdf[NUM_EVENTOS] > min) & (resultdf[NUM_EVENTOS] <= max)
         resultdf = resultdf.loc[result2]
         return resultdf
 
-    def events_between_dates(self, dataframe, initial, final, onlystudents=False):
+    def events_between_dates(self, initial, final, onlystudents=False):
         """
         Summary line. SPRINT01
 
@@ -567,8 +521,6 @@ class Maadle():
 
         Parameters
         ----------
-        dataframe : dataframe
-            Log en el que calcular el número de eventos.
         initial : int
             Límite inferior del rango.
         final : int
@@ -583,10 +535,12 @@ class Maadle():
 
         """
         if onlystudents:
-            resultdf = Maadle.delete_by_ID(self, dataframe, self.teachers)
-            resultdf = Maadle.events_per_day(self, resultdf)
+            aux = self.dataframe
+            self.dataframe = Maadle.delete_by_ID(self, self.teachers)
+            resultdf = Maadle.events_per_day(self)
+            self.dataframe = aux
         else:
-            resultdf = Maadle.events_per_day(self, dataframe)
+            resultdf = Maadle.events_per_day(self)
         result2 = (resultdf['Fecha'] >= initial) & (resultdf['Fecha'] <= final)
         resultdf = resultdf.loc[result2]
         return resultdf

--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -15,6 +15,7 @@ class Maadle():
     dataframe = pd.DataFrame
     teachers = []
     dataframe_usuarios = pd.DataFrame
+    dataframe_recursos = pd.DataFrame
     def __init__(self, name, path, usuariosxls, userstodelete):
         if path!="":
             self.dataframe=Maadle.create_data_frame(self, name, path)
@@ -26,6 +27,11 @@ class Maadle():
         self.dataframe=Maadle.change_hora_type(self.dataframe)
         self.dataframe=Maadle.add_mont_day_hour_columns(self, self.dataframe)
         self.dataframe = self.dataframe.sort_values(by=[FECHA_HORA])
+        self.dataframe_usuarios = pd.DataFrame(self.dataframe[NOMBRE_USUARIO].unique(),columns =[NOMBRE_USUARIO])
+        self.dataframe_recursos = pd.DataFrame(self.dataframe[CONTEXTO].unique(),columns =[CONTEXTO])
+        with pd.ExcelWriter('ConfigPrez.xlsx') as writer:
+            self.dataframe_usuarios.to_excel(writer, sheet_name='Usuarios', index=False)
+            self.dataframe_recursos.to_excel(writer, sheet_name='Recursos', index=False)
         self.dataframe_usuarios = pd.read_excel(usuariosxls, sheet_name='Usuarios')
 
     def create_data_frame(self, name, path) -> pd.DataFrame:

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -15,6 +15,11 @@ while True:
         usuarios=input("Introduza el nombre del fichero de usuarios, no olvides el .xls ")
         print("Introduza los ids de los usuarios a eliminar separados por un espacio ",end="")
         idprofesores = list(map(str, input().split()))
+        print(len(idprofesores))
+        soloalumnos = True
+        if len(idprofesores) is 0:
+            idprofesores.append("x")
+            soloalumnos = False
 
         prueba = (Maadle.Maadle(log, "", usuarios, idprofesores))
 
@@ -67,8 +72,8 @@ app.layout = html.Div(children=[
                     dash_table.DataTable(
                         id='table',
                         columns=[{"name": i, "id": i} for i in
-                                 prueba.list_nonparticipant(prueba.dataframe, prueba.dataframe_usuarios).columns],
-                        data=prueba.list_nonparticipant(prueba.dataframe, prueba.dataframe_usuarios).to_dict(
+                                 prueba.list_nonparticipant().columns],
+                        data=prueba.list_nonparticipant().to_dict(
                             'records'),
                         style_header={'backgroundColor': colors['background']},
                         style_cell={'textAlign': 'left',
@@ -92,11 +97,9 @@ app.layout = html.Div(children=[
                             'data': [
                                 {'labels': [Maadle.PARTICIPANTES, Maadle.NO_PARTICIPANTES],
                                  'values': [
-                                     prueba.num_participants_nonparticipants(prueba.dataframe,
-                                                                             prueba.dataframe_usuarios)[
+                                     prueba.num_participants_nonparticipants()[
                                          Maadle.PARTICIPANTES][0],
-                                     prueba.num_participants_nonparticipants(prueba.dataframe,
-                                                                             prueba.dataframe_usuarios)[
+                                     prueba.num_participants_nonparticipants()[
                                          Maadle.NO_PARTICIPANTES][0]], 'type': 'pie',
                                  'automargin': True,
                                  'textinfo': 'none'
@@ -122,8 +125,8 @@ app.layout = html.Div(children=[
         id='ParticipantesPorRecurso',
         figure={
             'data': [
-                {'x': prueba.participants_per_resource(prueba.dataframe)[Maadle.NUM_PARTICIPANTES],
-                 'y': prueba.participants_per_resource(prueba.dataframe)[RECURSO], 'type': 'bar', 'orientation': 'h'},
+                {'x': prueba.participants_per_resource()[Maadle.NUM_PARTICIPANTES],
+                 'y': prueba.participants_per_resource()[RECURSO], 'type': 'bar', 'orientation': 'h'},
             ],
             'layout': {
                 'title': 'Participantes por recurso',
@@ -152,10 +155,10 @@ app.layout = html.Div(children=[
                 id='my-date-picker-range',
                 display_format='D/M/Y',
                 style={'font-size': '20px'},
-                min_date_allowed=prueba.events_per_day(prueba.dataframe)[FECHA].min(),
-                max_date_allowed=prueba.events_per_day(prueba.dataframe)[FECHA].max(),
-                start_date=prueba.events_per_day(prueba.dataframe)[FECHA].min(),
-                end_date=prueba.events_per_day(prueba.dataframe)[FECHA].max(),
+                min_date_allowed=prueba.events_per_day()[FECHA].min(),
+                max_date_allowed=prueba.events_per_day()[FECHA].max(),
+                start_date=prueba.events_per_day()[FECHA].min(),
+                end_date=prueba.events_per_day()[FECHA].max(),
             ),
             dcc.Graph(id='graph-events-per-day-students'),
         ],style={'background': colors['grey']}
@@ -165,8 +168,8 @@ dcc.Graph(
         id='EventosPorRecurso',
         figure={
             'data': [
-                {'x': prueba.events_per_resource(prueba.dataframe)[Maadle.NUM_EVENTOS],
-                 'y': prueba.events_per_resource(prueba.dataframe)[RECURSO], 'type': 'bar', 'orientation': 'h'},
+                {'x': prueba.events_per_resource()[Maadle.NUM_EVENTOS],
+                 'y': prueba.events_per_resource()[RECURSO], 'type': 'bar', 'orientation': 'h'},
             ],
             'layout': {
                 'title': 'Recursos por número de eventos',
@@ -191,7 +194,8 @@ dcc.Graph(
     [dash.dependencies.Input('my-date-picker-range', 'start_date'),
      dash.dependencies.Input('my-date-picker-range', 'end_date')])
 def update_output(start_date, end_date):
-    dfaux5 = prueba.events_between_dates(prueba.dataframe, start_date, end_date, True)
+
+    dfaux5 = prueba.events_between_dates(start_date, end_date, soloalumnos)
     return {
         'data': [
             {'x': dfaux5[FECHA], 'y': dfaux5[Maadle.NUM_EVENTOS], 'type': 'scatter'},

--- a/EjerciciosLog/Test_Maadle.py
+++ b/EjerciciosLog/Test_Maadle.py
@@ -21,19 +21,19 @@ class Test_Maadle(unittest.TestCase):
         self.assertEqual(len(dataframe), 99)
 
     def test_addIDColumn(self):
-        dataframe=prueba1Rows.add_ID_column(prueba1Rows.dataframe) #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
+        dataframe=prueba1Rows.add_ID_column() #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
         self.assertTrue(Maadle.ID_USUARIO in dataframe.columns)
-        dataframe=prueba99Rows.add_ID_column(prueba1Rows.dataframe) #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
+        dataframe=prueba99Rows.add_ID_column() #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
         self.assertTrue(Maadle.ID_USUARIO in dataframe.columns)
 
     def test_deleteColumns(self):
-        dataframe=prueba1Rows.delete_columns(prueba1Rows.dataframe, [Maadle.DESCRIPCION])
+        dataframe=prueba1Rows.delete_columns([Maadle.DESCRIPCION])
         self.assertFalse(Maadle.DESCRIPCION in dataframe.columns)
 
     def test_deleteByID(self):
         dataframe=prueba1Rows.dataframe
         self.assertTrue("0" in dataframe[Maadle.ID_USUARIO].values)
-        dataframe=prueba1Rows.delete_by_ID(prueba1Rows.dataframe, ["0"])
+        dataframe=prueba1Rows.delete_by_ID(["0"])
         self.assertTrue("0" not in dataframe[Maadle.ID_USUARIO].values)
 
     def test_changeHoraType(self):
@@ -45,10 +45,10 @@ class Test_Maadle(unittest.TestCase):
     def test_betweenDates(self):
         ini = np.datetime64('2019-08-01')
         fin = np.datetime64('2019-08-29')
-        self.assertEqual(len(prueba99Rows.between_dates(prueba99Rows.dataframe, ini, fin)), 1)
+        self.assertEqual(len(prueba99Rows.between_dates(ini, fin)), 1)
         ini = np.datetime64('2019-09-01')
         fin = np.datetime64('2019-09-10')
-        self.assertEqual(len(prueba99Rows.between_dates(prueba99Rows.dataframe, ini, fin)), 5)
+        self.assertEqual(len(prueba99Rows.between_dates(ini, fin)), 5)
 
 
     def test_addMontDayHourColumns(self):
@@ -62,47 +62,45 @@ class Test_Maadle(unittest.TestCase):
         self.assertTrue(('HoraDelDía' in dataframe.columns))
 
     def test_numEvents(self):
-        self.assertTrue(prueba1Rows.num_events(prueba1Rows.dataframe) == 1)
-        self.assertTrue(prueba99Rows.num_events(prueba99Rows.dataframe) == 53)
+        self.assertTrue(prueba1Rows.num_events() == 1)
+        self.assertTrue(prueba99Rows.num_events() == 53)
 
     def test_numTeachers(self):
-        self.assertTrue(prueba1Rows.num_teachers(prueba1Rows.dataframe) == 1)
-        self.assertTrue(prueba99Rows.num_teachers(prueba99Rows.dataframe) == 1)
+        self.assertTrue(prueba1Rows.num_teachers() == 1)
+        self.assertTrue(prueba99Rows.num_teachers() == 1)
 
 
     def test_numParticipantsPerSubject(self):
-        self.assertTrue((prueba1Rows.num_participants_per_subject(prueba1Rows.dataframe) == 0))
-        self.assertTrue((prueba99Rows.num_participants_per_subject(prueba99Rows.dataframe) == 12))
+        self.assertTrue((prueba1Rows.num_participants_per_subject() == 0))
+        self.assertTrue((prueba99Rows.num_participants_per_subject() == 12))
 
 
     def test_numEventsPerParticipant(self):
-        self.assertTrue((((prueba1Rows.num_events_per_participant(prueba1Rows.dataframe))[Maadle.NUM_EVENTOS][0]) == 1))
+        self.assertTrue((((prueba1Rows.num_events_per_participant())[Maadle.NUM_EVENTOS][0]) == 1))
 
     def test_num_participants_nonparticipants(self):
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants())[
                             Maadle.PARTICIPANTES][0] == 13)
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+        self.assertTrue((prueba99Rows.num_participants_nonparticipants())[
                             Maadle.NO_PARTICIPANTES][0] == 4)
 
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99RowsSinUsuarios.dataframe,prueba99RowsSinUsuarios.dataframe_usuarios))[
+        self.assertTrue((prueba99RowsSinUsuarios.num_participants_nonparticipants())[
                             Maadle.PARTICIPANTES][0] == 13)
-        self.assertTrue((prueba99Rows.num_participants_nonparticipants(prueba99RowsSinUsuarios.dataframe,prueba99RowsSinUsuarios.dataframe_usuarios))[
+        self.assertTrue((prueba99RowsSinUsuarios.num_participants_nonparticipants())[
                             Maadle.NO_PARTICIPANTES][0] == 0)
 
 
 
     def test_list_nonparticipant(self):
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+        self.assertTrue((prueba99Rows.list_nonparticipant())[
                             Maadle.NOMBRE_USUARIO][0] == 'Sanchez Barreiro, Pablo')
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+        self.assertTrue((prueba99Rows.list_nonparticipant())[
                             Maadle.NOMBRE_USUARIO][1] == 'Pedro')
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+        self.assertTrue((prueba99Rows.list_nonparticipant())[
                             Maadle.NOMBRE_USUARIO][2] == 'JAVI')
-        self.assertTrue((prueba99Rows.list_nonparticipant(prueba99Rows.dataframe,prueba99Rows.dataframe_usuarios))[
+        self.assertTrue((prueba99Rows.list_nonparticipant())[
                             Maadle.NOMBRE_USUARIO][3] == 'RODRIGUEZ PÉREZ, DANIEL')
-
-
-        self.assertTrue('TODOS HAN PARTICIPADO' in (prueba99Rows.list_nonparticipant(prueba99RowsSinUsuarios.dataframe, prueba99RowsSinUsuarios.dataframe_usuarios).columns))
+        self.assertTrue('TODOS HAN PARTICIPADO' in (prueba99RowsSinUsuarios.list_nonparticipant().columns))
 
 
     def test_eventsPerMonth(self):
@@ -115,79 +113,79 @@ class Test_Maadle(unittest.TestCase):
         self.assertEqual(0,0)
 
     def test_eventsPerResource(self):
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[0][Maadle.NUM_EVENTOS], 32)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[0][Maadle.NUM_EVENTOS], 32)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[1][Maadle.NUM_EVENTOS], 13)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[1][RECURSO], "Foro: Noticias de clase")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[1][Maadle.NUM_EVENTOS], 13)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[1][RECURSO], "Foro: Noticias de clase")
 
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[2][Maadle.NUM_EVENTOS], 4)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[2][RECURSO], "Carpeta: Recursos del Alumnado")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[2][Maadle.NUM_EVENTOS], 4)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[2][RECURSO], "Carpeta: Recursos del Alumnado")
 
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[3][Maadle.NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[3][RECURSO], "Carpeta: Entrega inicial")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[3][Maadle.NUM_EVENTOS], 1)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[3][RECURSO], "Carpeta: Entrega inicial")
 
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[4][Maadle.NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[4][RECURSO], "Carpeta: Exámenes")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[4][Maadle.NUM_EVENTOS], 1)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[4][RECURSO], "Carpeta: Exámenes")
 
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[5][Maadle.NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[5][RECURSO], "Carpeta: Papeleo")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[5][Maadle.NUM_EVENTOS], 1)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[5][RECURSO], "Carpeta: Papeleo")
 
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[6][Maadle.NUM_EVENTOS], 1)
-        self.assertEqual(prueba99Rows.events_per_resource(prueba99Rows.dataframe).iloc[6][RECURSO], "Tarea: Entrega inicial")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[6][Maadle.NUM_EVENTOS], 1)
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[6][RECURSO], "Tarea: Entrega inicial")
 
-        self.assertEqual(prueba1Rows.events_per_resource(prueba1Rows.dataframe).iloc[0][Maadle.NUM_EVENTOS], 1)
-        self.assertEqual(prueba1Rows.events_per_resource(prueba1Rows.dataframe).iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba1Rows.events_per_resource().iloc[0][Maadle.NUM_EVENTOS], 1)
+        self.assertEqual(prueba1Rows.events_per_resource().iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
     def test_events_between_dates(self):
         ini = np.datetime64('2019-08-01')
         fin = np.datetime64('2019-08-29')
-        dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin)
+        dataframe=prueba99Rows.events_between_dates(ini, fin)
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-08-01'][Maadle.NUM_EVENTOS].to_string(index=False), " 1")
         ini = np.datetime64('2019-09-01')
         fin = np.datetime64('2019-09-10')
-        dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin)
+        dataframe=prueba99Rows.events_between_dates(ini, fin)
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False), " 3")
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-05'][Maadle.NUM_EVENTOS].to_string(index=False), " 1")
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-02'][Maadle.NUM_EVENTOS].to_string(index=False), " 1")
         ini = np.datetime64('2019-09-09')
         fin = np.datetime64('2019-09-23')
-        dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin)
+        dataframe=prueba99Rows.events_between_dates(ini, fin)
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False), " 3")
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-22'][Maadle.NUM_EVENTOS].to_string(index=False), " 4")
         self.assertEqual(len(dataframe), 2)
-        dataframe=prueba99Rows.events_between_dates(prueba99Rows.dataframe, ini, fin,True)
+        dataframe=prueba99Rows.events_between_dates(ini, fin,True)
         self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False), " 3")
         self.assertEqual(len(dataframe), 1)
 
     def test_participants_per_resource(self):
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[0][
                              Maadle.NUM_PARTICIPANTES], 13)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[1][
                              Maadle.NUM_PARTICIPANTES], 2)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[1][RECURSO], "Carpeta: Recursos del Alumnado")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[1][RECURSO], "Carpeta: Recursos del Alumnado")
 
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[2][
                              Maadle.NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[2][RECURSO], "Carpeta: Entrega inicial")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[2][RECURSO], "Carpeta: Entrega inicial")
 
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[3][
                              Maadle.NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[3][RECURSO], "Carpeta: Exámenes")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[3][RECURSO], "Carpeta: Exámenes")
 
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[4][
                              Maadle.NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[4][RECURSO], "Carpeta: Papeleo")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[4][RECURSO], "Carpeta: Papeleo")
 
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[5][
                              Maadle.NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[5][RECURSO], "Foro: Noticias de clase")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[5][RECURSO], "Foro: Noticias de clase")
 
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6][
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[6][
                              Maadle.NUM_PARTICIPANTES], 1)
-        self.assertEqual(prueba99Rows.participants_per_resource(prueba99Rows.dataframe).iloc[6][RECURSO], "Tarea: Entrega inicial")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[6][RECURSO], "Tarea: Entrega inicial")
 
 
     def test_eventsPerHour(self):


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era refactorizar Maadle para simplificar los parámetros que utilizaban las distintas funciones de las que disponía. Estas funciones solían tomar un dataframe, que normalmente era el propio dataframe que proporcionaba Maadle. De esta forma, se hacía innecesario que se proporcionase constantemente.

De esta forma, lo que se hizo fue ir suprimiento esos parámetros, que si bien eso limitaba un poco la libertad de las funciones, era más lógico. Por norma general, se intentó que las funciones no modificaran el estado del dataframe que contiene el log, sino que efectúen sus cambios sobre una copia que es la que se devuelve. De cara a facilitar las cosas con Prez. La función _events_between_dates_ es la que más problemas dio, pues utilizaba otra pasándole un dataframe que no era el propio de Maadle. 

Por otro lado, se adaptaron Prez y Test_Maadle al nuevo formato de las funciones y se comprobó que seguían ejecutándose satisfactoriamente las pruebas. Prez requirió ciertos cambios en la entrada por consola de sus parámetros. Por lo demás, no hubo ningún problema. Las funciones están perfectamente adaptadas, así como Prez y la clase de pruebas.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.