### PR TITLE
Us384068 num interacciones por usuario periodo

### DIFF
--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -560,6 +560,22 @@ class Maadle:
         return resultdf
 
     def events_per_day_per_user(self, usuario):
+        """
+        Summary line.
+
+        Calcula el número de eventos de un usuario concreto por día del log.
+
+        Parameters
+        ----------
+        usuario : String
+            Nombre del usuario a analizar.
+
+        Returns
+        -------
+        series
+            Lista con los días y su número de eventos.
+
+        """
         result = 0
         df = self.dataframe[[FECHA_HORA,NOMBRE_USUARIO]]
         df = df[df[NOMBRE_USUARIO].str.contains(usuario)]

--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -559,6 +559,16 @@ class Maadle:
         resultdf = resultdf.loc[result2]
         return resultdf
 
+    def events_per_day_per_user(self, usuario):
+        result = 0
+        df = self.dataframe[[FECHA_HORA,NOMBRE_USUARIO]]
+        df = df[df[NOMBRE_USUARIO].str.contains(usuario)]
+        result = df[FECHA_HORA].groupby(df.Hora.dt.strftime('%Y-%m-%d')).agg('count') + result
+        resultdf = (pd.DataFrame(data=result.values, index=result.index, columns=[NUM_EVENTOS]))
+        resultdf['Fecha'] = resultdf.index
+        resultdf['Fecha'] = pd.to_datetime(resultdf['Fecha'])
+        resultdf.reset_index(drop=True, inplace=True)
+        return resultdf
 
     """
     Calcula la media de eventos por participante del dataframe.

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -157,7 +157,6 @@ app.layout = html.Div(children=[
                 'textAlign': 'left',
                 'color': colors['text'],
                 'font-size': '20px'},
-
                      ),
             dcc.DatePickerRange(
                 id='my-date-picker-range',
@@ -195,6 +194,22 @@ dcc.Graph(
             }
         },
     ),
+html.Div(children=[
+        html.Div(children='Seleccione a un usuario ', style={
+        'textAlign': 'left',
+        'color': colors['text'],
+        'font-size': '20px'},
+             ),
+        dcc.Dropdown(
+            id='users-dropdown',
+            options=[{'label': i, 'value': i} for i in prezz.dataframe[Maadle.NOMBRE_USUARIO].unique()
+            ],
+            searchable=True,
+            placeholder="Seleccione a un usuario",
+            value=prezz.dataframe_usuarios[Maadle.NOMBRE_USUARIO][0]
+        ),
+        dcc.Graph(id='graph-events-per-day-per-student')
+    ], style={'background': colors['grey']}),
 ])
 
 
@@ -218,6 +233,26 @@ def update_output(start_date, end_date):
             }
         },
     }
+
+@app.callback(
+    dash.dependencies.Output('graph-events-per-day-per-student', 'figure'),
+    [dash.dependencies.Input('users-dropdown', 'value')])
+def update_output(value):
+    dfaux6 = prezz.events_per_day_per_user(value)
+    return {
+        'data': [
+            {'x': dfaux6[FECHA], 'y': dfaux6[Maadle.NUM_EVENTOS], 'type': 'scatter'},
+        ],
+        'layout': {
+            'title': 'Eventos por rango de días por alumno',
+            'plot_bgcolor': colors['background'],
+            'paper_bgcolor': colors['grey'],
+            'font': {
+                'color': colors['text']
+            }
+        },
+    }
+
 
 
 if __name__ == '__main__':

--- a/EjerciciosLog/Test_Maadle.py
+++ b/EjerciciosLog/Test_Maadle.py
@@ -14,7 +14,7 @@ prueba99RowsTodosUsuarios = (Maadle.Maadle("TestingLog99RowsTodosUsuarios.csv", 
 class Test_Maadle(unittest.TestCase):
 
     def test_createDataFrame(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
 
     def test_createDataFrameFileName(self):
         dataframe = prueba1Rows.create_data_frame_file_fame("TestingLog1Row.csv")
@@ -23,26 +23,26 @@ class Test_Maadle(unittest.TestCase):
         self.assertEqual(len(dataframe), 99)
 
     def test_addIDColumn(self):
-        dataframe=prueba1Rows.add_ID_column() #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
+        dataframe = prueba1Rows.add_ID_column()  # Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
         self.assertTrue(Maadle.ID_USUARIO in dataframe.columns)
-        dataframe=prueba99Rows.add_ID_column() #Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
+        dataframe = prueba99Rows.add_ID_column()  # Ya la tiene en el constructor, probada borrándolo y añadiéndolo aquí
         self.assertTrue(Maadle.ID_USUARIO in dataframe.columns)
 
     def test_deleteColumns(self):
-        dataframe=prueba1Rows.delete_columns([Maadle.DESCRIPCION])
+        dataframe = prueba1Rows.delete_columns([Maadle.DESCRIPCION])
         self.assertFalse(Maadle.DESCRIPCION in dataframe.columns)
 
     def test_deleteByID(self):
-        dataframe=prueba1Rows.dataframe
+        dataframe = prueba1Rows.dataframe
         self.assertTrue("0" in dataframe[Maadle.ID_USUARIO].values)
-        dataframe=prueba1Rows.delete_by_ID(["0"])
+        dataframe = prueba1Rows.delete_by_ID(["0"])
         self.assertTrue("0" not in dataframe[Maadle.ID_USUARIO].values)
 
     def test_changeHoraType(self):
-        dataframe=prueba1Rows.dataframe
-        self.assertEqual(dataframe[Maadle.FECHA_HORA].dtype, 'datetime64[ns]')# Se hace en el constructor
-        dataframe=prueba99Rows.dataframe
-        self.assertEqual(dataframe[Maadle.FECHA_HORA].dtype, 'datetime64[ns]')# Se hace en el constructor
+        dataframe = prueba1Rows.dataframe
+        self.assertEqual(dataframe[Maadle.FECHA_HORA].dtype, 'datetime64[ns]')  # Se hace en el constructor
+        dataframe = prueba99Rows.dataframe
+        self.assertEqual(dataframe[Maadle.FECHA_HORA].dtype, 'datetime64[ns]')  # Se hace en el constructor
 
     def test_betweenDates(self):
         ini = np.datetime64('2019-08-01')
@@ -52,14 +52,13 @@ class Test_Maadle(unittest.TestCase):
         fin = np.datetime64('2019-09-10')
         self.assertEqual(len(prueba99Rows.between_dates(ini, fin)), 5)
 
-
     def test_addMontDayHourColumns(self):
-        dataframe=prueba1Rows.dataframe
-        self.assertTrue(('MesDelAño'in dataframe.columns))# Se hace en el constructor
+        dataframe = prueba1Rows.dataframe
+        self.assertTrue(('MesDelAño' in dataframe.columns))  # Se hace en el constructor
         self.assertTrue(('DíaDelMes' in dataframe.columns))
         self.assertTrue(('HoraDelDía' in dataframe.columns))
-        dataframe=prueba99Rows.dataframe
-        self.assertTrue(('MesDelAño'in dataframe.columns))# Se hace en el constructor
+        dataframe = prueba99Rows.dataframe
+        self.assertTrue(('MesDelAño' in dataframe.columns))  # Se hace en el constructor
         self.assertTrue(('DíaDelMes' in dataframe.columns))
         self.assertTrue(('HoraDelDía' in dataframe.columns))
 
@@ -71,11 +70,9 @@ class Test_Maadle(unittest.TestCase):
         self.assertTrue(prueba1Rows.num_teachers() == 1)
         self.assertTrue(prueba99Rows.num_teachers() == 1)
 
-
     def test_numParticipantsPerSubject(self):
         self.assertTrue((prueba1Rows.num_participants_per_subject() == 0))
         self.assertTrue((prueba99Rows.num_participants_per_subject() == 12))
-
 
     def test_numEventsPerParticipant(self):
         self.assertTrue((((prueba1Rows.num_events_per_participant())[Maadle.NUM_EVENTOS][0]) == 1))
@@ -91,8 +88,6 @@ class Test_Maadle(unittest.TestCase):
         self.assertTrue((prueba99RowsTodosUsuarios.num_participants_nonparticipants())[
                             Maadle.NO_PARTICIPANTES][0] == 0)
 
-
-
     def test_list_nonparticipant(self):
         self.assertTrue((prueba99Rows.list_nonparticipant())[
                             Maadle.NOMBRE_USUARIO][0] == 'Sanchez Barreiro, Pablo')
@@ -104,19 +99,19 @@ class Test_Maadle(unittest.TestCase):
                             Maadle.NOMBRE_USUARIO][3] == 'RODRIGUEZ PÉREZ, DANIEL')
         self.assertTrue('TODOS HAN PARTICIPADO' in (prueba99RowsTodosUsuarios.list_nonparticipant().columns))
 
-
     def test_eventsPerMonth(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
 
     def test_eventsPerWeek(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
 
     def test_eventsPerDay(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
 
     def test_eventsPerResource(self):
         self.assertEqual(prueba99Rows.events_per_resource().iloc[0][Maadle.NUM_EVENTOS], 32)
-        self.assertEqual(prueba99Rows.events_per_resource().iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba99Rows.events_per_resource().iloc[0][RECURSO],
+                         "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
         self.assertEqual(prueba99Rows.events_per_resource().iloc[1][Maadle.NUM_EVENTOS], 13)
         self.assertEqual(prueba99Rows.events_per_resource().iloc[1][RECURSO], "Foro: Noticias de clase")
@@ -137,33 +132,42 @@ class Test_Maadle(unittest.TestCase):
         self.assertEqual(prueba99Rows.events_per_resource().iloc[6][RECURSO], "Tarea: Entrega inicial")
 
         self.assertEqual(prueba1Rows.events_per_resource().iloc[0][Maadle.NUM_EVENTOS], 1)
-        self.assertEqual(prueba1Rows.events_per_resource().iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba1Rows.events_per_resource().iloc[0][RECURSO],
+                         "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
     def test_events_between_dates(self):
         ini = np.datetime64('2019-08-01')
         fin = np.datetime64('2019-08-29')
-        dataframe=prueba99Rows.events_between_dates(ini, fin)
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-08-01'][Maadle.NUM_EVENTOS].to_string(index=False), " 1")
+        dataframe = prueba99Rows.events_between_dates(ini, fin)
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-08-01'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 1")
         ini = np.datetime64('2019-09-01')
         fin = np.datetime64('2019-09-10')
-        dataframe=prueba99Rows.events_between_dates(ini, fin)
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False), " 3")
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-05'][Maadle.NUM_EVENTOS].to_string(index=False), " 1")
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-02'][Maadle.NUM_EVENTOS].to_string(index=False), " 1")
+        dataframe = prueba99Rows.events_between_dates(ini, fin)
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 3")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-05'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 1")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-02'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 1")
         ini = np.datetime64('2019-09-09')
         fin = np.datetime64('2019-09-23')
-        dataframe=prueba99Rows.events_between_dates(ini, fin)
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False), " 3")
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-22'][Maadle.NUM_EVENTOS].to_string(index=False), " 4")
+        dataframe = prueba99Rows.events_between_dates(ini, fin)
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 3")
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-22'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 4")
         self.assertEqual(len(dataframe), 2)
-        dataframe=prueba99Rows.events_between_dates(ini, fin,True)
-        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False), " 3")
+        dataframe = prueba99Rows.events_between_dates(ini, fin, True)
+        self.assertEqual(dataframe.loc[dataframe[FECHA] == '2019-09-09'][Maadle.NUM_EVENTOS].to_string(index=False),
+                         " 3")
         self.assertEqual(len(dataframe), 1)
 
     def test_participants_per_resource(self):
         self.assertEqual(prueba99Rows.participants_per_resource().iloc[0][
                              Maadle.NUM_PARTICIPANTES], 13)
-        self.assertEqual(prueba99Rows.participants_per_resource().iloc[0][RECURSO], "Curso: G000 - Curso de Testing - Curso 2018-2019")
+        self.assertEqual(prueba99Rows.participants_per_resource().iloc[0][RECURSO],
+                         "Curso: G000 - Curso de Testing - Curso 2018-2019")
 
         self.assertEqual(prueba99Rows.participants_per_resource().iloc[1][
                              Maadle.NUM_PARTICIPANTES], 2)
@@ -189,15 +193,41 @@ class Test_Maadle(unittest.TestCase):
                              Maadle.NUM_PARTICIPANTES], 1)
         self.assertEqual(prueba99Rows.participants_per_resource().iloc[6][RECURSO], "Tarea: Entrega inicial")
 
+    def test_events_per_day_per_user(self):
+        self.assertEqual(prueba99Rows.events_per_day_per_user("CUADRIELLO GALDÓS, ÁNGELA")[Maadle.NUM_EVENTOS][0], 4)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("CUADRIELLO GALDÓS, ÁNGELA")[Maadle.NUM_EVENTOS][1], 1)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("CUADRIELLO GALDÓS, ÁNGELA")[Maadle.NUM_EVENTOS][1], 1)
+
+        self.assertEqual(prueba99Rows.events_per_day_per_user("CUEVAS RODRIGUEZ, SARA")[Maadle.NUM_EVENTOS][0], 1)
+
+        self.assertEqual(prueba99Rows.events_per_day_per_user("CIMAS CAMPOS, NOIVE")[Maadle.NUM_EVENTOS][0], 2)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("CIMAS CAMPOS, NOIVE")[Maadle.NUM_EVENTOS][1], 1)
+
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][0], 2)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][1], 1)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][2], 3)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][3], 4)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][4], 8)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][5], 3)
+        self.assertEqual(prueba99Rows.events_per_day_per_user("Pérez González, Docente")[Maadle.NUM_EVENTOS][6], 6)
+
+
+
+
+
+
+
+
 
     def test_eventsPerHour(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
 
     def test_resourcesByNumberOfEvents(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
 
     def test_averageEventsPerParticipant(self):
-        self.assertEqual(0,0)
+        self.assertEqual(0, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/EjerciciosLog/assets/style.css
+++ b/EjerciciosLog/assets/style.css
@@ -481,3 +481,20 @@ there.
     stroke: black;
     fill: transparent;
 }
+
+/* Dropdown */
+.Select.has-value.is-clearable.Select--single > .Select-control .Select-value {
+    padding-right: 42px;
+    background: black;
+    border: 1px solid white;
+}
+
+.Select, .Select div, .Select input, .Select span {
+    box-sizing: border-box;
+    color: #7FDBFF;
+    background: black;
+}
+
+Select.has-value.Select--single > .Select-control .Select-value .Select-value-label, .Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label {
+    color: #7FDBFF;
+}


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de esta historia de usuario era permitir al usuario conocer el número de interacciones de un usuario concreto a lo largo del tiempo. Para ello quería permitirse al usuario elegir al usuario del que mostrar la información para luego mostrarla en forma de gráfica.

Así, se ha añadido la función _events_per_day_per_user_, que recibiendo el nombre del usuario al que analizar, retorna un dataframe con el número de interacciones del usuarios y las fechas en las que ocurrieron. Esos son los únicos cambios que afectaron a Maadle.

Por otro lado, en Prez se añadió una gráfica que se actualiza con un dropdown con los nombres de los distintos usuarios, de forma dinámica. Así mismo, se ha aprovechado para modificar el css y adaptarlo al estilo del resto de la interfaz.

Para terminar, se implementaron pruebas unitarias para validar el correcto funcionamiento de la función añadida y se pasaron las pruebas de aceptación para ver que todo funcionaba como se esperaba.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.