### PR TITLE
Us384836 solucionar problemas css

### DIFF
--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -33,7 +33,14 @@ while True:
     else:
         break
 
-app = dash.Dash(__name__, assets_folder='assets/')
+def find_data_file(filename):
+    if getattr(sys, 'frozen', False):
+        datadir = os.path.dirname(sys.executable)
+    else:
+        datadir = os.path.realpath('.')
+    return os.path.join(datadir, filename)
+
+app = dash.Dash(__name__, assets_folder=find_data_file('assets/'))
 
 server = app.server
 colors = {

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -33,16 +33,7 @@ while True:
     else:
         break
 
-
-def find_data_file(filename):
-    if getattr(sys, 'frozen', False):
-        datadir = os.path.dirname(sys.executable)
-    else:
-        datadir = os.path.dirname("C:/Users/sal8b/OneDrive/Escritorio/LibreriaMoodleAnalisis/EjerciciosLog/assets")
-    return os.path.join(datadir, filename)
-
-
-app = dash.Dash(__name__, assets_folder=find_data_file('assets/'))
+app = dash.Dash(__name__, assets_folder='assets/')
 
 server = app.server
 colors = {


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era solucionar problemas en la carga de style.css en dispositivos que no sean el de desarrollo. Para ello se esperaba poder proporcionar un ruta relativa en la que buscar tal fichero.

Lo que se hizo fue actualizar la función de prez _find_data_file_ para que buscase a partir del directorio en el que se encuentra Prez, pudiendo usar así una ruta relativa. Este cambio se efectuó utilizando la función _ralpath_. Al hacerlo, el estilo seguía cargando en el entorno de desarrollo sin problemas.

Para comprobar, que efectivamente se cumplían los requisitos se generó un ejecutable y se instaló en otro dispositivo. Los resultados fueron satisfactorios, quedando así el problema resulto.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.