### PR TITLE
Us384072 etiqueta nombre curso

### DIFF
--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -18,12 +18,14 @@ class Maadle:
     dataframe = pd.DataFrame
     dataframe_usuarios = pd.DataFrame
     dataframe_recursos = pd.DataFrame
+    nombre_curso = 'Curso de Moodle'
     def __init__(self, name, path, config):
 
         if path != "":
             self.dataframe = Maadle.create_data_frame(self, name, path)
         else:
             self.dataframe = Maadle.create_data_frame_file_fame(self, name)
+        self.nombre_curso = self.dataframe[self.dataframe['Contexto del evento'].str.contains("Curso:")]['Contexto del evento'].iloc[0]
         self.dataframe = Maadle.add_ID_column(self)
         self.dataframe = self.dataframe[~self.dataframe[NOMBRE_USUARIO].isin(['-'])]
         self.dataframe = Maadle.change_hora_type(self)

--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -25,7 +25,8 @@ class Maadle:
             self.dataframe = Maadle.create_data_frame(self, name, path)
         else:
             self.dataframe = Maadle.create_data_frame_file_fame(self, name)
-        self.nombre_curso = self.dataframe[self.dataframe['Contexto del evento'].str.contains("Curso:")]['Contexto del evento'].iloc[0]
+        if len(self.dataframe[self.dataframe['Contexto del evento'].str.contains("Curso:")]['Contexto del evento']) != 0:
+            self.nombre_curso = self.dataframe[self.dataframe['Contexto del evento'].str.contains("Curso:")]['Contexto del evento'].iloc[0]
         self.dataframe = Maadle.add_ID_column(self)
         self.dataframe = self.dataframe[~self.dataframe[NOMBRE_USUARIO].isin(['-'])]
         self.dataframe = Maadle.change_hora_type(self)

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -84,7 +84,7 @@ app.layout = html.Div(children=[
 
     html.H2(
         children=
-        prezz.dataframe[prezz.dataframe['Contexto del evento'].str.contains("Curso:")]['Contexto del evento'].iloc[0],
+        prezz.nombre_curso,
         style={
             'textAlign': 'center',
             'color': colors['text'],

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -83,8 +83,7 @@ colors = {
 app.layout = html.Div(children=[
 
     html.H2(
-        children=
-        prezz.nombre_curso,
+        children=prezz.nombre_curso,
         style={
             'textAlign': 'center',
             'color': colors['text'],


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era permitir al usuario establecer un alias para el recurso con el nombre del curso sin que esto impidiese que se ejecutara el análisis, como sucedía hasta el momento.

De esta forma, lo que se hizo es guardar el valor de ese nombre antes de dar la opción al usuario de cambiarlo. Y por otro lado, se estableció uno por defecto por si en el log no se encontrase tipado de la forma que debería.

Una vez realizado el presalvado en Maadle, desde Prez se utilizó tal variable para mostrar el nombre del curso, permitiendo así que el análisis se ejecutase correctamente a pesar de que el usuario estableciese un alias para el curso.

Tras esto y para terminar, se pasaron las pruebas unitarias y de aceptación satisfactoriamente.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.