### PR TITLE
Us386570 externalizar interfaz

### DIFF
--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -1,129 +1,16 @@
+import Maadle
+import PrezGUI
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
-import Maadle
 import dash_table
 import os
-import webbrowser
 from tkinter import *
-from tkinter import filedialog
-from tkinter import messagebox
 
 RECURSO = 'Recurso'
 FECHA = 'Fecha'
 
-
-def clicked_btn_log():
-    windowLog.log = filedialog.askopenfilename(initialdir=".", title="Select file",
-                                               filetypes=(("csv files", "*.csv"), ("all files", "*.*")))
-
-
-def clicked_btn_config():
-    windowConfig.config = filedialog.askopenfilename(initialdir=".", title="Select file",
-                                                     filetypes=(("xlsx files", "*.xlsx"), ("all files", "*.*")))
-
-
-def clicked_btn_create():
-    windowCreateConfig.config = txt_config_name.get()
-    if windowCreateConfig.config.isspace() or windowCreateConfig.config == "":
-        messagebox.showerror("Error", "Escriba un nombre para el fichero de configuración")
-    else:
-        windowCreateConfig.config = windowCreateConfig.config + '.xlsx'
-        windowCreateConfig.destroy()
-
-
-def clicked_btn_accept():
-    if not isinstance(windowConfig.config, str) or windowConfig.config == "":
-        if windowCreateConfig.config != "":
-            windowConfig.config = windowCreateConfig.config
-            webbrowser.open_new("http://localhost:8080")
-            windowConfig.destroy()
-        else:
-            messagebox.showerror("Error", "Seleccione un fichero de configuración")
-    else:
-        webbrowser.open_new("http://localhost:8080")
-        windowConfig.destroy()
-
-
-def clicked_btn_siguiente():
-    if not hasattr(windowLog, 'log') or windowLog.log == "":
-        messagebox.showerror("Error", "Seleccione un fichero log")
-    else:
-        windowLog.destroy()
-
-
-def clicked_btn_skip():
-    windowCreateConfig.config = ""
-    windowCreateConfig.destroy()
-
-
-def on_closing():
-    if messagebox.askokcancel("Cancelar", "¿Seguro que quiere cancelar el análisis?"):
-        windowConfig.destroy()
-
-
-windowLog = Tk()
-windowLog.title("Prez")
-windowLog.iconbitmap("assets/favicon.ico")
-
-mensaje_log = Text(windowLog, width=40, height=14)
-mensaje_log.insert(INSERT, "Bienvenido a Prez. Le acompañaremos en la configuración de su análisis. \n"
-                           "\nEn primer lugar, pulse  'Seleccione el fichero log' y elija el fichero "
-                           "log del curso que quiera analizar. "
-                           "Si actualmente no lo tiene, acceda a la sección de informes de Moodle y descargue, en"
-                           " formato .csv, el log del curso deseado. \n"
-                           "\nUna vez seleccionado el fichero, pulse 'Siguiente'.")
-btn_log = Button(windowLog, text="Seleccione el fichero log", command=clicked_btn_log)
-btn_siguiente = Button(windowLog, text="Siguiente", command=clicked_btn_siguiente)
-
-mensaje_log.pack(fill=X)
-btn_log.pack(fill=X)
-btn_siguiente.pack(fill=X)
-
-windowLog.mainloop()
-
-windowCreateConfig = Tk()
-windowCreateConfig.title("Prez")
-windowCreateConfig.iconbitmap("assets/favicon.ico")
-
-mensaje_create = Text(windowCreateConfig, width=40, height=14)
-mensaje_create.insert(INSERT, "Prez le permite proporcionar fichero Excel de configuración con datos adicionales del"
-                              " curso.\n \nSi actualmente no dispone de este fichero, proporcione un nombre para "
-                              "el mismo, pulse 'Crear' y uno será creado (en la carpeta de instalación de Prez)"
-                              " y utilizado automáticamente en el análisis.\n"
-                              "\nSi ya dispone de un fichero Excel de configuración pulse 'Saltar este paso'.")
-btn_create = Button(windowCreateConfig, text="Crear", command=clicked_btn_create)
-btn_skip = Button(windowCreateConfig, text="Saltar este paso", command=clicked_btn_skip)
-
-mensaje_create.pack(fill=X)
-txt_config_name = Entry(windowCreateConfig)
-txt_config_name.pack(fill=X)
-btn_create.pack(fill=X)
-btn_skip.pack(fill=X)
-
-windowCreateConfig.mainloop()
-
-windowConfig = Tk()
-windowConfig.title("Prez")
-windowConfig.iconbitmap("assets/favicon.ico")
-
-mensaje_config = Text(windowConfig, width=40, height=14)
-mensaje_config.insert(INSERT, "Para terminar, si no ha creado un fichero de configuración en el paso previo pulse "
-                              "'Seleccione el fichero de configuración y elija el fichero on el que quiera realizar "
-                              "el análisis.\n \nUna vez creado o seleccionado el fichero de configuración, pulse "
-                              "'Aceptar' y el análisis será mostrado en su navegador web.")
-
-btn_config = Button(windowConfig, text="Seleccione el fichero de configuración", command=clicked_btn_config)
-btn_accept = Button(windowConfig, text="Aceptar", command=clicked_btn_accept)
-windowConfig.protocol("WM_DELETE_WINDOW", on_closing)
-
-mensaje_config.pack(fill=X)
-btn_config.pack(fill=X)
-btn_accept.pack(fill=X)
-
-windowConfig.mainloop()
-
-prezz = (Maadle.Maadle(windowLog.log, "", windowConfig.config))
+prezz = (Maadle.Maadle(PrezGUI.windowLog.log, "", PrezGUI.windowConfig.config))
 
 
 def find_data_file(filename):

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -6,9 +6,12 @@ import dash_core_components as dcc
 import dash_table
 import os
 from tkinter import *
+import webbrowser
+
 
 RECURSO = 'Recurso'
 FECHA = 'Fecha'
+
 
 prezz = (Maadle.Maadle(PrezGUI.windowLog.log, "", PrezGUI.windowConfig.config))
 
@@ -29,6 +32,7 @@ colors = {
     'text': '#7FDBFF',
     'grey': 'rgb(50, 50, 50)'
 }
+webbrowser.open_new("http://localhost:8080")
 
 app.layout = html.Div(children=[
 

--- a/EjerciciosLog/PrezGUI.py
+++ b/EjerciciosLog/PrezGUI.py
@@ -1,0 +1,115 @@
+import webbrowser
+from tkinter import filedialog
+from tkinter import messagebox
+from tkinter import *
+
+
+def clicked_btn_log():
+    windowLog.log = filedialog.askopenfilename(initialdir=".", title="Select file",
+                                               filetypes=(("csv files", "*.csv"), ("all files", "*.*")))
+
+
+def clicked_btn_config():
+    windowConfig.config = filedialog.askopenfilename(initialdir=".", title="Select file",
+                                                     filetypes=(("xlsx files", "*.xlsx"), ("all files", "*.*")))
+
+
+def clicked_btn_create():
+    windowCreateConfig.config = txt_config_name.get()
+    if windowCreateConfig.config.isspace() or windowCreateConfig.config == "":
+        messagebox.showerror("Error", "Escriba un nombre para el fichero de configuración")
+    else:
+        windowCreateConfig.config = windowCreateConfig.config + '.xlsx'
+        windowCreateConfig.destroy()
+
+
+def clicked_btn_accept():
+    if not isinstance(windowConfig.config, str) or windowConfig.config == "":
+        if windowCreateConfig.config != "":
+            windowConfig.config = windowCreateConfig.config
+            webbrowser.open_new("http://localhost:8080")
+            windowConfig.destroy()
+        else:
+            messagebox.showerror("Error", "Seleccione un fichero de configuración")
+    else:
+        webbrowser.open_new("http://localhost:8080")
+        windowConfig.destroy()
+
+
+def clicked_btn_siguiente():
+    if not hasattr(windowLog, 'log') or windowLog.log == "":
+        messagebox.showerror("Error", "Seleccione un fichero log")
+    else:
+        windowLog.destroy()
+
+
+def clicked_btn_skip():
+    windowCreateConfig.config = ""
+    windowCreateConfig.destroy()
+
+
+def on_closing():
+    if messagebox.askokcancel("Cancelar", "¿Seguro que quiere cancelar el análisis?"):
+        windowConfig.destroy()
+
+
+windowLog = Tk()
+windowLog.title("Prez")
+windowLog.iconbitmap("assets/favicon.ico")
+
+mensaje_log = Text(windowLog, width=40, height=14)
+mensaje_log.insert(INSERT, "Bienvenido a Prez. Le acompañaremos en la configuración de su análisis. \n"
+                           "\nEn primer lugar, pulse  'Seleccione el fichero log' y elija el fichero "
+                           "log del curso que quiera analizar. "
+                           "Si actualmente no lo tiene, acceda a la sección de informes de Moodle y descargue, en"
+                           " formato .csv, el log del curso deseado. \n"
+                           "\nUna vez seleccionado el fichero, pulse 'Siguiente'.")
+btn_log = Button(windowLog, text="Seleccione el fichero log", command=clicked_btn_log)
+btn_siguiente = Button(windowLog, text="Siguiente", command=clicked_btn_siguiente)
+
+mensaje_log.pack(fill=X)
+btn_log.pack(fill=X)
+btn_siguiente.pack(fill=X)
+
+windowLog.mainloop()
+
+windowCreateConfig = Tk()
+windowCreateConfig.title("Prez")
+windowCreateConfig.iconbitmap("assets/favicon.ico")
+
+mensaje_create = Text(windowCreateConfig, width=40, height=14)
+mensaje_create.insert(INSERT, "Prez le permite proporcionar fichero Excel de configuración con datos adicionales del"
+                              " curso.\n \nSi actualmente no dispone de este fichero, proporcione un nombre para "
+                              "el mismo, pulse 'Crear' y uno será creado (en la carpeta de instalación de Prez)"
+                              " y utilizado automáticamente en el análisis.\n"
+                              "\nSi ya dispone de un fichero Excel de configuración pulse 'Saltar este paso'.")
+btn_create = Button(windowCreateConfig, text="Crear", command=clicked_btn_create)
+btn_skip = Button(windowCreateConfig, text="Saltar este paso", command=clicked_btn_skip)
+
+mensaje_create.pack(fill=X)
+txt_config_name = Entry(windowCreateConfig)
+txt_config_name.pack(fill=X)
+btn_create.pack(fill=X)
+btn_skip.pack(fill=X)
+
+windowCreateConfig.mainloop()
+
+windowConfig = Tk()
+windowConfig.title("Prez")
+windowConfig.iconbitmap("assets/favicon.ico")
+
+mensaje_config = Text(windowConfig, width=40, height=14)
+mensaje_config.insert(INSERT, "Para terminar, si no ha creado un fichero de configuración en el paso previo pulse "
+                              "'Seleccione el fichero de configuración y elija el fichero on el que quiera realizar "
+                              "el análisis.\n \nUna vez creado o seleccionado el fichero de configuración, pulse "
+                              "'Aceptar' y el análisis será mostrado en su navegador web.")
+
+btn_config = Button(windowConfig, text="Seleccione el fichero de configuración", command=clicked_btn_config)
+btn_accept = Button(windowConfig, text="Aceptar", command=clicked_btn_accept)
+windowConfig.protocol("WM_DELETE_WINDOW", on_closing)
+
+mensaje_config.pack(fill=X)
+btn_config.pack(fill=X)
+btn_accept.pack(fill=X)
+
+windowConfig.mainloop()

--- a/EjerciciosLog/PrezGUI.py
+++ b/EjerciciosLog/PrezGUI.py
@@ -1,4 +1,3 @@
-import webbrowser
 from tkinter import filedialog
 from tkinter import messagebox
 from tkinter import *
@@ -15,24 +14,20 @@ def clicked_btn_config():
 
 
 def clicked_btn_create():
-    windowCreateConfig.config = txt_config_name.get()
-    if windowCreateConfig.config.isspace() or windowCreateConfig.config == "":
-        messagebox.showerror("Error", "Escriba un nombre para el fichero de configuración")
-    else:
-        windowCreateConfig.config = windowCreateConfig.config + '.xlsx'
-        windowCreateConfig.destroy()
+    windowCreateConfig.config = filedialog.asksaveasfilename(initialdir=".", title="Select file",
+                               filetypes=(("xlsx files", "*.xlsx"), ("all files", "*.*")))
+    windowCreateConfig.config = windowCreateConfig.config + '.xlsx'
+    windowCreateConfig.destroy()
 
 
 def clicked_btn_accept():
     if not isinstance(windowConfig.config, str) or windowConfig.config == "":
         if windowCreateConfig.config != "":
             windowConfig.config = windowCreateConfig.config
-            webbrowser.open_new("http://localhost:8080")
             windowConfig.destroy()
         else:
             messagebox.showerror("Error", "Seleccione un fichero de configuración")
     else:
-        webbrowser.open_new("http://localhost:8080")
         windowConfig.destroy()
 
 
@@ -87,8 +82,6 @@ btn_create = Button(windowCreateConfig, text="Crear", command=clicked_btn_create
 btn_skip = Button(windowCreateConfig, text="Saltar este paso", command=clicked_btn_skip)
 
 mensaje_create.pack(fill=X)
-txt_config_name = Entry(windowCreateConfig)
-txt_config_name.pack(fill=X)
 btn_create.pack(fill=X)
 btn_skip.pack(fill=X)
 

--- a/EjerciciosLog/PrezGUI.py
+++ b/EjerciciosLog/PrezGUI.py
@@ -52,7 +52,7 @@ windowLog = Tk()
 windowLog.title("Prez")
 windowLog.iconbitmap("assets/favicon.ico")
 
-mensaje_log = Text(windowLog, width=40, height=14)
+mensaje_log = Text(windowLog, wrap=WORD, font='Helvetica', width=40, height=14)
 mensaje_log.insert(INSERT, "Bienvenido a Prez. Le acompañaremos en la configuración de su análisis. \n"
                            "\nEn primer lugar, pulse  'Seleccione el fichero log' y elija el fichero "
                            "log del curso que quiera analizar. "
@@ -72,11 +72,11 @@ windowCreateConfig = Tk()
 windowCreateConfig.title("Prez")
 windowCreateConfig.iconbitmap("assets/favicon.ico")
 
-mensaje_create = Text(windowCreateConfig, width=40, height=14)
+mensaje_create = Text(windowCreateConfig, wrap=WORD, font='Helvetica', width=40, height=14)
 mensaje_create.insert(INSERT, "Prez le permite proporcionar fichero Excel de configuración con datos adicionales del"
-                              " curso.\n \nSi actualmente no dispone de este fichero, proporcione un nombre para "
-                              "el mismo, pulse 'Crear' y uno será creado (en la carpeta de instalación de Prez)"
-                              " y utilizado automáticamente en el análisis.\n"
+                              " curso.\n \nSi actualmente no dispone de este fichero pulse 'Crear' y proporcione un"
+                              "nombre y un lugar para que uno sea generado con los datos por defecto. De generarlo"
+                              "en este punto, no hace falta que seleccione ninguno en el siguiente paso\n"
                               "\nSi ya dispone de un fichero Excel de configuración pulse 'Saltar este paso'.")
 btn_create = Button(windowCreateConfig, text="Crear", command=clicked_btn_create)
 btn_skip = Button(windowCreateConfig, text="Saltar este paso", command=clicked_btn_skip)
@@ -91,7 +91,7 @@ windowConfig = Tk()
 windowConfig.title("Prez")
 windowConfig.iconbitmap("assets/favicon.ico")
 
-mensaje_config = Text(windowConfig, width=40, height=14)
+mensaje_config = Text(windowConfig, wrap=WORD, font='Helvetica', width=40, height=14)
 mensaje_config.insert(INSERT, "Para terminar, si no ha creado un fichero de configuración en el paso previo pulse "
                               "'Seleccione el fichero de configuración y elija el fichero on el que quiera realizar "
                               "el análisis.\n \nUna vez creado o seleccionado el fichero de configuración, pulse "


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era crear una clase propia para para la interfaz de configuración de Prez. Ese apartado empezaba a tener cierta complejidad, por lo que era mejor tratarlo por separado.

De esta forma, lo que se hizo fue crear una clase PrezGUI, en ella, se introdujo todo el código relativo a la configuración de Prez. Para hacerlo, se quito de Prez, donde estaba actualmente. Al hacerlo todo parecía funcionar correctamente, salvo la apertura del buscador, que en ocasiones se abría más rápido de lo que el análisis se ejecutaba, dando a entender que no había análisis ninguno. Para solucionarlo, se dejó la instrucción de apertura del buscador en Prez, para ser ejecutada una vez se contase con el análisis.

Una vez hecho lo anterior mencionado, se decidió dedicar este ticket para ciertas tareas relacioandas con la interfaz:

- Se cambió la fuente monospaced de las ventanas de configuración por una más acorde con el estilo.
- La separación en líneas del texto de las ventanas cortaba palabras, se ha cambiado para que las separe correctamente. Separación de líneas a nivel de palabra y no de línea.
-Se permite al usuario crear el fichero de configuración donde quiera, no solo en el directorio de instalación de Prez. Se ha actualizado la interfaz en consecuencia, el campo de texto para el nombre de configuración ahora innecesario y los textos con las instrucciones a seguir.

Por último, se comprobó que efectivamente se cumplían las pruebas de aceptación.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.