### PR TITLE
Us386272 cambiar extension xlsx

### DIFF
--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -41,6 +41,8 @@ class Maadle:
             with pd.ExcelWriter(config) as writer:
                 self.dataframe_usuarios.to_excel(writer, sheet_name='Usuarios', index=False)
                 self.dataframe_recursos.to_excel(writer, sheet_name='Recursos', index=False)
+                writer.sheets['Usuarios'].set_column('A:A', self.dataframe_usuarios[NOMBRE_USUARIO].map(len).max())
+                writer.sheets['Recursos'].set_column('A:B', self.dataframe_recursos[CONTEXTO].map(len).max())
         self.dataframe_usuarios = pd.ExcelFile(config).parse('Usuarios')
         self.dataframe_recursos = pd.ExcelFile(config).parse('Recursos')
         for i in range(self.dataframe_recursos[CONTEXTO].size):


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era hacer que los ficheros de configuración creados fuesen xls y no xlsx. Así se solucionarían ciertos problemas de compatibilidad.

De esta forma, inicialmente se cambió la creación del excel de configuración para que utilizase el motor xlrd y poder así crear ficheros xls, en lugar de xlsx. Sin embargo, si se quiere, como se apuntó en algún momento, poder regular el ancho de las columnas, el fichero habrá de ser obligatoriamente xlsx. Finalmente, se ha optado por dejar el xlsx y adaptar la anchura de las columnas al tamaño del string más largo de tal columna.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.