### PR TITLE
Us387039 cambiar estilo prez

### DIFF
--- a/EjerciciosLog/Maadle.py
+++ b/EjerciciosLog/Maadle.py
@@ -693,14 +693,14 @@ class Maadle:
 
         """
         df = Maadle.create_dynamic_session_id(self)
-        dfaux = self.dataframe_recursos
-        lista_recursos = dfaux[CONTEXTO].to_list()
-        rows = dfaux[CONTEXTO].nunique()
+        dfe = self.dataframe[CONTEXTO].unique()
+        lista_recursos = dfe.tolist()
+        rows = len(dfe)
         columns = rows
         matrix = [[0 for x in range(columns)] for x in range(rows)]
         for session, event in df.groupby(ID_SESION):
             resource_iterador = 0
-            for resource in dfaux[CONTEXTO]:
+            for resource in dfe:
                 if resource in event[CONTEXTO].values:
                     matrix[resource_iterador][resource_iterador] = matrix[resource_iterador][resource_iterador]+1
                     for recource_in_event in event[CONTEXTO].unique():

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -26,9 +26,9 @@ app = dash.Dash(__name__, assets_folder=find_data_file('assets/'))
 app.title = 'Prez'
 server = app.server
 colors = {
-    'background': '#111111',
-    'text': '#7FDBFF',
-    'grey': 'rgb(50, 50, 50)'
+    'background': '#FFFFFF',
+    'text': '#111111',
+    'grey': '#E9E9E9'
 }
 
 app.layout = html.Div(

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -256,14 +256,15 @@ app.layout = html.Div(
                     'x': prezz.dataframe_recursos[Maadle.CONTEXTO],
                     'y': prezz.dataframe_recursos[Maadle.CONTEXTO],
                     'z': prezz.sessions_matrix(),
+                    'colorscale': [[0, 'white'], [1, 'red']],
                     'ygap': 1,
                     'xgap': 1,
                     'type': 'heatmap',
                 }],
                 'layout': {
                     'title': 'Sesiones',
-                    'yaxis': {'automargin': True},
-                    'xaxis': {'automargin': True},
+                    'yaxis': {'automargin': True, 'visible': False},
+                    'xaxis': {'automargin': True, 'visible': False},
                     'plot_bgcolor': colors['background'],
                     'paper_bgcolor': colors['grey'],
                     'font': {

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -7,7 +7,6 @@ import dash_table
 import os
 from tkinter import *
 import webbrowser
-
 RECURSO = 'Recurso'
 FECHA = 'Fecha'
 
@@ -28,7 +27,9 @@ server = app.server
 colors = {
     'background': '#FFFFFF',
     'text': '#111111',
-    'grey': '#E9E9E9'
+    'grey': '#E9E9E9',
+    'uc_color': 'rgb(0,103,113)',
+    'uc_inverse_color': 'rgb(113,10,0)'
 }
 
 app.layout = html.Div(
@@ -118,15 +119,17 @@ app.layout = html.Div(
                             id='pie-chart-participants-users',
                             figure={
                                 'data': [
-                                    {'labels': [Maadle.PARTICIPANTES, Maadle.NO_PARTICIPANTES],
-                                     'values': [
-                                         prezz.num_participants_nonparticipants()[
-                                             Maadle.PARTICIPANTES][0],
-                                         prezz.num_participants_nonparticipants()[
-                                             Maadle.NO_PARTICIPANTES][0]], 'type': 'pie',
-                                     'automargin': True,
-                                     'textinfo': 'none'
-                                     },
+                                    {
+                                        'labels': [Maadle.PARTICIPANTES, Maadle.NO_PARTICIPANTES],
+                                        'marker': dict(colors=[colors['uc_color'], colors['uc_inverse_color']]),
+                                        'values': [
+                                            prezz.num_participants_nonparticipants()[
+                                                Maadle.PARTICIPANTES][0],
+                                            prezz.num_participants_nonparticipants()[
+                                                Maadle.NO_PARTICIPANTES][0]], 'type': 'pie',
+                                        'automargin': True,
+                                        'textinfo': 'none',
+                                    },
                                 ],
                                 'layout': {
                                     'title': 'Eventos por recurso',
@@ -149,7 +152,9 @@ app.layout = html.Div(
             figure={
                 'data': [
                     {'x': prezz.participants_per_resource()[Maadle.NUM_PARTICIPANTES],
-                     'y': prezz.participants_per_resource()[RECURSO], 'type': 'bar', 'orientation': 'h'},
+                     'y': prezz.participants_per_resource()[RECURSO], 'type': 'bar', 'orientation': 'h', 'marker': {
+                        'color': colors['uc_color']}
+                     },
                 ],
                 'layout': {
                     'title': 'Participantes por recurso',
@@ -194,7 +199,8 @@ app.layout = html.Div(
             figure={
                 'data': [
                     {'x': prezz.events_per_resource()[Maadle.NUM_EVENTOS],
-                     'y': prezz.events_per_resource()[RECURSO], 'type': 'bar', 'orientation': 'h'},
+                     'y': prezz.events_per_resource()[RECURSO], 'type': 'bar', 'orientation': 'h', 'marker': {
+                        'color': 'rgb(0, 103, 113)'}},
                 ],
                 'layout': {
                     'title': 'Recursos por número de eventos',
@@ -256,7 +262,7 @@ app.layout = html.Div(
                     'x': prezz.dataframe_recursos[Maadle.CONTEXTO],
                     'y': prezz.dataframe_recursos[Maadle.CONTEXTO],
                     'z': prezz.sessions_matrix(),
-                    'colorscale': [[0, 'white'], [1, 'red']],
+                    'colorscale': [[0, 'white'], [1, colors['uc_inverse_color']]],
                     'ygap': 1,
                     'xgap': 1,
                     'type': 'heatmap',
@@ -272,6 +278,7 @@ app.layout = html.Div(
                     }
                 }})
     ])
+webbrowser.open_new("http://localhost:8080")
 
 
 @app.callback(
@@ -282,18 +289,19 @@ def update_output(start_date, end_date):
     dfaux5 = prezz.events_between_dates(start_date, end_date)
     return {
         'data': [
-            {'x': dfaux5[FECHA], 'y': dfaux5[Maadle.NUM_EVENTOS], 'type': 'scatter'},
+            {'x': dfaux5[FECHA], 'y': dfaux5[Maadle.NUM_EVENTOS], 'type': 'scatter',
+             'line': dict(color=colors['uc_color'])},
         ],
         'layout': {
             'title': 'Eventos por rango de días',
             'plot_bgcolor': colors['background'],
             'paper_bgcolor': colors['grey'],
+
             'font': {
                 'color': colors['text']
             }
         },
     }
-webbrowser.open_new("http://localhost:8080")
 
 
 @app.callback(
@@ -303,7 +311,10 @@ def update_output(value):
     dfaux6 = prezz.events_per_day_per_user(value)
     return {
         'data': [
-            {'x': dfaux6[FECHA], 'y': dfaux6[Maadle.NUM_EVENTOS], 'type': 'bar'},
+            {'x': dfaux6[FECHA], 'y': dfaux6[Maadle.NUM_EVENTOS], 'type': 'bar',
+             'marker': {
+                 'color': colors['uc_color']}
+             },
         ],
         'layout': {
             'title': 'Eventos por rango de días por alumnos',
@@ -323,7 +334,8 @@ def update_output(value):
     dfaux7 = prezz.events_per_day_per_resource(value)
     return {
         'data': [
-            {'x': dfaux7[FECHA], 'y': dfaux7[Maadle.NUM_EVENTOS], 'type': 'bar'},
+            {'x': dfaux7[FECHA], 'y': dfaux7[Maadle.NUM_EVENTOS], 'type': 'bar', 'marker': {
+                'color': colors['uc_color']}},
         ],
         'layout': {
             'title': 'Eventos por rango de días por recurso',

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -321,7 +321,7 @@ app.layout = html.Div(
                     options=[{'label': i, 'value': i} for i in prezz.dataframe[Maadle.CONTEXTO].unique()
                              ],
                     searchable=True,
-                    placeholder="Seleccione a un usuario",
+                    placeholder="Seleccione un recurso",
                     value=prezz.dataframe_recursos[Maadle.CONTEXTO][0]
                 ),
                 dcc.Graph(id='graph-events-per-day-per-resource')

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -7,6 +7,7 @@ import dash_table
 import os
 from tkinter import *
 import webbrowser
+
 RECURSO = 'Recurso'
 FECHA = 'Fecha'
 
@@ -80,6 +81,75 @@ app.layout = html.Div(
                            }
                 ),
             ]),
+        html.Div(id="info-container",
+                 className="eight columns",
+                 children=[
+                     html.Div(id="num-events",
+                              className="pretty_container four columns",
+                              children=[
+                                  html.H6(children="Núm. Interacciones"),
+                                  html.P(str(len(prezz.dataframe)))],
+                              style={
+                                  'width': 'auto',
+                                  'color': 'white',
+                                  'box-shadow': '2px 2px 2px ' + colors['uc_inverse_color'],
+                                  'background-color': colors['uc_color'],
+                              }
+                              ),
+                     html.Div(id="num-participants",
+                              className="pretty_container four columns",
+                              children=[
+                                  html.H6(children="Núm. Participantes"),
+                                  html.P(str(prezz.num_participants_nonparticipants()[
+                                                Maadle.PARTICIPANTES][0]))],
+                              style={
+                                  'width': 'auto',
+                                  'color': 'white',
+                                  'box-shadow': '2px 2px 2px ' + colors['uc_inverse_color'],
+                                  'background-color': colors['uc_color'],
+                              }
+                              ),
+                     html.Div(id="num-no-participants",
+                              className="pretty_container four columns",
+                              children=[
+                                  html.H6(children="Núm. No Participantes"),
+                                  html.P(str(prezz.num_participants_nonparticipants()[
+                                                 Maadle.NO_PARTICIPANTES][0]))],
+                              style={
+                                  'width': 'auto',
+                                  'color': 'white',
+                                  'box-shadow': '2px 2px 2px ' + colors['uc_inverse_color'],
+                                  'background-color': colors['uc_color'],
+                              }
+                              ),
+                     html.Div(id="top-participant",
+                              className="pretty_container four columns",
+                              children=[
+                                  html.H6(children="Máx. Interacciones"),
+                                  html.P(prezz.num_events_per_participant()[Maadle.NOMBRE_USUARIO].tail(1))],
+                              style={
+                                  'width': 'auto',
+                                  'color': 'white',
+                                  'box-shadow': '2px 2px 2px ' + colors['uc_inverse_color'],
+                                  'background-color': colors['uc_color'],
+                              }
+                              ),
+                     html.Div(id="bottom-participant",
+                              className="pretty_container four columns",
+                              children=[
+                                  html.H6(children="Mín. Interacciones"),
+                                  html.P(prezz.num_events_per_participant()[Maadle.NOMBRE_USUARIO].head(1))],
+                              style={
+                                  'width': 'auto',
+                                  'color': 'white',
+                                  'box-shadow': '2px 2px 2px ' + colors['uc_inverse_color'],
+                                  'background-color': colors['uc_color'],
+                              }
+                              )
+                 ],
+                 style={
+                     'width': '100%',
+                     'margin-left': '0%'}),
 
         html.Div(
             children=[

--- a/EjerciciosLog/Prez.py
+++ b/EjerciciosLog/Prez.py
@@ -30,7 +30,6 @@ colors = {
     'text': '#7FDBFF',
     'grey': 'rgb(50, 50, 50)'
 }
-webbrowser.open_new("http://localhost:8080")
 
 app.layout = html.Div(
     style={'margin': '3%'},
@@ -293,6 +292,7 @@ def update_output(start_date, end_date):
             }
         },
     }
+webbrowser.open_new("http://localhost:8080")
 
 
 @app.callback(

--- a/EjerciciosLog/assets/style.css
+++ b/EjerciciosLog/assets/style.css
@@ -482,6 +482,11 @@ there.
     fill: transparent;
 }
 */
+.CalendarDay__selected_span {
+    background: #006771;
+    border: 1px double #710a00;
+    color: #fff;
+}
 
 /* Dropdown
 .Select.has-value.is-clearable.Select--single > .Select-control .Select-value {

--- a/EjerciciosLog/assets/style.css
+++ b/EjerciciosLog/assets/style.css
@@ -513,3 +513,12 @@ Select.has-value.Select--single > .Select-control .Select-value .Select-value-la
 .one-third.column {
     width: 100px;
 }
+/* Pretty container*/
+.pretty_container {
+  border-radius: 5px;
+  background-color: #f9f9f9;
+  margin: 10px;
+  padding: 15px;
+  position: relative;
+  box-shadow: 2px 2px 2px lightgrey;
+}

--- a/EjerciciosLog/assets/style.css
+++ b/EjerciciosLog/assets/style.css
@@ -128,7 +128,7 @@ are based on 10px sizing. So basically 1.5rem = 15px :) */
 html {
   font-size: 62.5%; }
 body {
-  background-color:#111111 ;
+  background-color:#FFFFFF ;
   font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
   line-height: 1.6;
   font-weight: 400;
@@ -249,8 +249,8 @@ textarea,
 select {
   height: 38px;
   padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
-  background-color: #111111;
-  color: #7FDBFF;
+  background-color: #FFFFFF;
+  color: #111111;
   border: 1px solid #D1D1D1;
   border-radius: 4px;
   box-shadow: none;
@@ -419,7 +419,7 @@ there.
 @media (min-width: 1200px) {}
 
 
-/* Calendar */
+/* Calendar
 .DateRangePickerInput {
     background-color: black;
     display: inline-block;
@@ -481,8 +481,9 @@ there.
     stroke: black;
     fill: transparent;
 }
+*/
 
-/* Dropdown */
+/* Dropdown
 .Select.has-value.is-clearable.Select--single > .Select-control .Select-value {
     padding-right: 42px;
     background: black;
@@ -497,7 +498,7 @@ there.
 
 Select.has-value.Select--single > .Select-control .Select-value .Select-value-label, .Select.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label {
     color: #7FDBFF;
-}
+} */
 /* Images header */
 
 .column, .columns {


### PR DESCRIPTION
En el punto actual esta rama podría darse por concluida. A continuación, comentaremos lo realizado.

El cometido de este ticket de mantenimiento era cambiar el estilo al que fuese ya el definitivo.

De esta manera, se adaptaron todos los fondos y colores de la interfaz para utilizar los colores de la UC. Además se dedicó el ticket a añadir una serie de indicadores generales de interés en la parte superior. Estos podrán ser eliminados si no convencen, o incluso incluir otro tipo de información.

De esta forma, esta rama podría darse por finalizada, tras la aprobación de otro integrante.